### PR TITLE
Add indent support for `ifndef

### DIFF
--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -203,11 +203,11 @@ function GetVerilog_SystemVerilogIndent()
         echom last_line
       endif
 
-  " `ifdef and `else
-  elseif last_line =~ '^\s*`\<\(ifdef\|else\)\>'
+  " `ifdef , `ifndef and `else
+  elseif last_line =~ '^\s*`\<\(ifdef\|ifndef\|else\)\>'
     let ind = ind + offset
     if vverb
-      echom "Indent after a `ifdef or `else statement."
+      echom "Indent after a `ifdef , `ifndef or `else statement."
       echom last_line
     endif
 

--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -276,11 +276,11 @@ function GetVerilog_SystemVerilogIndent()
       echom last_line
     endif
 
-  " De-indent `else and `endif
-  elseif curr_line =~ '^\s*`\<\(else\|endif\)\>'
+  " De-indent `else , `elsif , or `endif
+  elseif curr_line =~ '^\s*`\<\(else\|elsif\|endif\)\>'
     let ind = ind - offset
     if vverb
-      echom "De-indent `else and `endif statement:"
+      echom "De-indent `else , `elsif , or `endif statement:"
       echom curr_line
     endif
 

--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -203,11 +203,11 @@ function GetVerilog_SystemVerilogIndent()
         echom last_line
       endif
 
-  " `ifdef , `ifndef and `else
-  elseif last_line =~ '^\s*`\<\(ifdef\|ifndef\|else\)\>'
+  " `ifdef , `ifndef , `elsif , or `else
+  elseif last_line =~ '^\s*`\<\(ifdef\|ifndef\|elsif\|else\)\>'
     let ind = ind + offset
     if vverb
-      echom "Indent after a `ifdef , `ifndef or `else statement."
+      echom "Indent after a `ifdef , `ifndef , `elsif or `else statement."
       echom last_line
     endif
 

--- a/test/indent.sv
+++ b/test/indent.sv
@@ -187,7 +187,7 @@ device d1 (
     device d3 ( .out(out), .* );
 `else
     device d3 ( .out(out), .portA(portB), .portB(portA) );
-`elsif 
+`endif
 
 endmodule
 

--- a/test/indent.sv
+++ b/test/indent.sv
@@ -178,6 +178,17 @@ device d1 (
     .portA(port[2])
 );
 
+`ifdef V95
+    device d2 ( out, portA, portB );
+`elsif V2K
+    device d2 ( .out(out), .* );
+`endif
+`ifndef SWAP
+    device d3 ( .out(out), .* );
+`else
+    device d3 ( .out(out), .portA(portB), .portB(portA) );
+`elsif 
+
 endmodule
 
 // vim: set sts=4 sw=4 nofen:


### PR DESCRIPTION
Indent support for ``ifndef` was missing. Minor change to fix it.
