### PR TITLE
Fix ftdetect

### DIFF
--- a/ftdetect/verilog_systemverilog.vim
+++ b/ftdetect/verilog_systemverilog.vim
@@ -1,4 +1,9 @@
 " Vim filetype plugin file
 " Language:	SystemVerilog (superset extension of Verilog)
 
-au! BufNewFile,BufRead *.v,*.vh,*.sv,*.svi,*.svh	setfiletype verilog_systemverilog
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+    finish
+endif
+
+au BufNewFile,BufRead *.v,*.vh,*.sv,*.svi,*.svh set filetype=verilog_systemverilog


### PR DESCRIPTION
This has been adopted from the ftdetect script of
vim-scripts/verilog_systemverilog.vim

setfiletype only executes when the filetype for the current buffer has
not been set yet.  Vim sets the filetype for *.v files to verilog
automatically, hence it won't execute.
