### PR TITLE
syntax: Allow folding of nested blocks

### DIFF
--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -230,7 +230,24 @@ if index(s:verilog_syntax_fold, "specify") >= 0 || index(s:verilog_syntax_fold, 
 else
     syn keyword verilogLabel      specify endspecify
 endif
-if index(s:verilog_syntax_fold, "block") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
+if index(s:verilog_syntax_fold, "block_nested") >= 0
+    syn region verilogFoldBlockContainer
+        \ start="\<begin\>"
+        \ end="\<end\>"
+        \ skip="/[*/].*"
+        \ transparent
+        \ keepend extend
+        \ containedin=ALLBUT,verilogComment
+        \ contains=NONE
+    syn region  verilogFold
+        \ start="\<begin\>"
+        \ end="\<end\>"me=s-1
+        \ transparent
+        \ fold
+        \ contained containedin=verilogFoldBlockContainer
+        \ contains=TOP
+    syn match verilogLabel "\<begin\|end\>"
+elseif index(s:verilog_syntax_fold, "block") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
     syn region  verilogFold
         \ matchgroup=verilogLabel
         \ start="\<begin\>"

--- a/test/folding.v
+++ b/test/folding.v
@@ -1,7 +1,7 @@
 function f;                                                   //<1>
 begin                                                         //<2>
                                                               //<2>
-end                                                           //<2>
+end                                                           //<2><1>
 endfunction : f                                               //<1>
                                                               //<0>
 task t;                                                       //<1>
@@ -9,7 +9,7 @@ task t;                                                       //<1>
 begin                                                         //<2>
     begin                                                     //<3>
     end                                                       //<3>
-end                                                           //<2>
+end                                                           //<2><1>
                                                               //<1>
 endtask : t                                                   //<1>
                                                               //<0>
@@ -158,4 +158,27 @@ reg test;                                                     //<1>
                                                               //<1>
   `endif                                                      //<1>
 */                                                            //<1>
-
+                                                              //<0>
+if (cond1) begin                                              //<1>
+    do1();                                                    //<1>
+end else if (cond2) begin                                     //<1>
+    do2();                                                    //<1>
+    do3();                                                    //<1>
+    do4();                                                    //<1>
+end else begin                                                //<1>
+    do5();                                                    //<1>
+end                                                           //<1><0>
+                                                              //<0>
+if (cond1)                                                    //<0>
+    do1();                                                    //<0>
+else if (cond2) begin                                         //<1>
+    do2();                                                    //<1>
+    begin                                                     //<2>
+    do2_1();                                                  //<2>
+    end                                                       //<2>
+    do3();                                                    //<1>
+    do4();                                                    //<1>
+end else begin                                                //<1>
+    do5();                                                    //<1>
+end                                                           //<1><0>
+// vi: set number norelativenumber :

--- a/test/run_test.vim
+++ b/test/run_test.vim
@@ -1,11 +1,17 @@
-function! TestFold()
+function! TestFold(...)
     let fail = 0
     let fail_lines = ''
     let linenr = 0
     while linenr < line("$")
         let linenr += 1
         let line = getline(linenr)
-        let linelvl = substitute(line, '.*<\(\d*\)>.*', '\1', '')
+        let levels = substitute(line, '.\{-}<\(\d*\)>', '\1,', 'g')
+        let levels_list = split(levels, ',')
+        if (len(levels_list) > 1 && a:0 > 0)
+          let linelvl=levels_list[a:1]
+        else
+          let linelvl=levels_list[0]
+        endif
         let level = foldlevel(linenr)
         if (level != linelvl)
             let fail = 1
@@ -78,6 +84,12 @@ view test/folding.v
 
 " Verify folding
 let test_result=TestFold() || test_result
+echo ''
+
+" Test with "block_nested"
+let g:verilog_syntax_fold="all,block_nested"
+silent view!
+let test_result=TestFold(1) || test_result
 echo ''
 
 "-----------------------------------------------------------------------


### PR DESCRIPTION
This is a special mode than is not enabled when g:verilog_syntax_fold is
set to "all". To enable it this variables must include the
"block_nested" keyword.

The folding test case includes the folding value expected for this
specific mode.
