### PR TITLE
Fix for issue 41.

### DIFF
--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -103,7 +103,8 @@ function GetVerilog_SystemVerilogIndent()
     \ last_line =~ '^\s*\<\(always\|always_comb\|always_ff\|always_latch\)\>' ||
     \ last_line =~ '^\s*\<\(initial\|specify\|fork\|final\)\>' ||
     \ last_line =~ '^\s*\(\w\+\s*:\s*\)\?\<\(assert\|assume\|cover\)\>'
-    if last_line !~ '\(;\|\<end\>\)\s*' . vlog_comment . '*$' ||
+    if ( last_line !~ '\<end\>\s*' . vlog_comment . '*$' &&
+      \ last_line !~ '\(;\|`\h\w*\((.*)\)\?\)\s*' . vlog_comment . '*$' ) ||
       \ last_line =~ '\(//\|/\*\).*\(;\|\<end\>\)\s*' . vlog_comment . '*$'
       let ind = ind + offset
       if vverb
@@ -263,7 +264,7 @@ function GetVerilog_SystemVerilogIndent()
 
   " De-indent else of assert
   elseif curr_line =~ '\<else\>' &&
-    \ last_line =~ '^\s*\(\w\+\s*:\s*\)\?\<\(assert\)\>\s*(.*)' . vlog_comment . '*$'
+    \ last_line =~ '^\s*\(\w\+\s*:\s*\)\?\<assert\(\s\+property\)\?\>\s*(.*)' . vlog_comment . '*$'
     let ind = ind - offset
     if vverb
       echom "De-indent else of assert"

--- a/test/indent.sv
+++ b/test/indent.sv
@@ -121,12 +121,29 @@ class z;
     // End of copied code
 
     // Code from: https://github.com/vhda/verilog_systemverilog.vim/issues/41
-    `uvm_info("TAG", "message", UVM_MEDIUM)
+    assert property (prop1)
+    else `uvm_fatal("TAG", "Assertion failed.")
+
+    do_something();
+
+    assert property (prop1)
+    else
+        `uvm_fatal("TAG", "Assertion failed.")
+
+    do_something();
 
     if (condition)
-        `uvm_info("TAG", "message1", UVM_MEDIUM)
+        something();
+    else `uvm_fatal("TAG", "This is invalid.")
+
+    do_something();
+
+    if (condition)
+        something();
     else
-        `uvm_info("TAG", "message2", UVM_NONE)
+        `uvm_fatal("TAG", "This is invalid.")
+
+    do_something();
     // End of copied code
 
     // Oter tests


### PR DESCRIPTION
-Don't indent after a macro.
-Added support for 'assert property'.
-Added examples for test.
