### PR TITLE
Func: Search for instance starting on end of line

### DIFF
--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -451,14 +451,14 @@ endfunction
 " External functions
 " {{{
 function verilog_systemverilog#GotoInstanceStart(line, column)
-  let values = s:GetInstanceInfo(a:line, 0)
+  let values = s:GetInstanceInfo(a:line, col('$'))
   if values[2] != ""
     call cursor(values[2], a:column)
   endif
 endfunction
 
 function verilog_systemverilog#FollowInstanceTag(line, column)
-  let values = s:GetInstanceInfo(a:line, 0)
+  let values = s:GetInstanceInfo(a:line, col('$'))
   if values[1] != ""
     execute "tag " . values[1]
   endif


### PR DESCRIPTION
This guarantees that the module name is found if the cursor is in the
same line as the start of the instance declaration, but isn't at the end
of the line.
