### PR TITLE
Func: Add commands to manage complex variables

### DIFF
--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -445,6 +445,129 @@ function verilog_systemverilog#Verbose(message)
     echom a:message
   endif
 endfunction
+
+" Configuration control
+" Pushes value to list only if new
+" Based on: http://vi.stackexchange.com/questions/6619/append-to-global-variable-and-completion
+function verilog_systemverilog#PushToVariable(variable, value)
+  if exists(a:variable) && len(split(a:variable, ',')) > 0
+    exec 'let ' . a:variable . ' .= ",' . a:value . '"'
+  else
+    exec 'let ' . a:variable . ' = "' . a:value . '"'
+  endif
+endfunction
+
+function verilog_systemverilog#PopFromVariable(variable, value)
+  if exists(a:variable)
+    exec 'let list = split(' . a:variable . ', ",")'
+    if len(list) > 0
+      exec 'let ' . a:variable . ' = "' . join(filter(list, 'v:val !=# a:value'), ',') . '"'
+    else
+      exec 'let ' . a:variable . ' = "' . a:value . '"'
+    endif
+  endif
+endfunction
+" }}}
+
+"------------------------------------------------------------------------
+" Command completion functions
+" {{{
+function verilog_systemverilog#CompleteCommand(lead, command, cursor)
+  " Get list with current values in variable
+  if (a:command =~ 'Folding')
+    if exists('g:verilog_syntax_fold')
+      let current_values = split(g:verilog_syntax_fold, ',')
+    else
+      let current_values = []
+    endif
+  elseif (a:command =~ 'Indent')
+    if exists('g:verilog_disable_indent')
+      let current_values = split(g:verilog_disable_indent, ',')
+    else
+      let current_values = []
+    endif
+  endif
+
+  " Create list with valid completion values depending on command type
+  if (a:command =~ 'FoldingAdd')
+    let valid_completions = [
+          \ 'all',
+          \ 'class',
+          \ 'function',
+          \ 'task',
+          \ 'specify',
+          \ 'interface',
+          \ 'clocking',
+          \ 'covergroup',
+          \ 'sequence',
+          \ 'property',
+          \ 'comment',
+          \ 'define',
+          \ 'instance'
+          \ ]
+    if (empty(filter(current_values, 'v:val =~ "^block"')))
+      let valid_completions += [
+            \ 'block',
+            \ 'block_nested',
+            \ 'block_named'
+            \ ]
+    endif
+    for item in current_values
+      call filter(valid_completions, 'v:val !=# item')
+    endfor
+  elseif (a:command =~ 'DisableIndentAdd')
+    let valid_completions = [
+          \ 'module',
+          \ 'interface',
+          \ 'class',
+          \ 'package',
+          \ 'covergroup',
+          \ 'program',
+          \ 'generate',
+          \ 'sequence',
+          \ 'property',
+          \ 'method',
+          \ 'preproc',
+          \ 'conditional'
+          \ ]
+    for item in current_values
+      call filter(valid_completions, 'v:val !=# item')
+    endfor
+  else
+    let valid_completions = current_values
+  endif
+
+  " If a:lead already includes other comma separated values, then remove
+  " all from the list of valid values except the last
+  let lead_list = split(a:lead, ',')
+  call verilog_systemverilog#Verbose('Current lead values list: [' . join(lead_list, ',') . '] (length = ' . len(lead_list) . ')')
+  call verilog_systemverilog#Verbose('Valid completions: [' . join(valid_completions, ',') . '] (length = ' . len(valid_completions) . ')')
+  if (a:lead =~ ',$')
+    let initial_lead = lead_list
+    let real_lead = ""
+  else
+    if (len(lead_list) > 1)
+      let initial_lead = lead_list[0:-2]
+      let real_lead = lead_list[-1]
+    else
+      let initial_lead = []
+      let real_lead = a:lead
+    endif
+  endif
+  call verilog_systemverilog#Verbose('Removing [' . join(initial_lead, ',') . '] from completion value list')
+  call verilog_systemverilog#Verbose('Searching using lead: "' . real_lead . '"')
+  for item in initial_lead
+    call filter(valid_completions, 'v:val !=# item')
+  endfor
+
+  let completion_list = filter(valid_completions, 'v:val =~ "^" . real_lead')
+
+  if (len(initial_lead) > 0)
+    return map(completion_list, 'join(initial_lead, ",") . "," . v:val')
+  else
+    return completion_list
+  endif
+endfunction
 " }}}
 
 "------------------------------------------------------------------------

--- a/doc/tags
+++ b/doc/tags
@@ -1,4 +1,8 @@
+:VerilogDisableIndentAdd	verilog_systemverilog.txt	/*:VerilogDisableIndentAdd*
+:VerilogDisableIndentRemove	verilog_systemverilog.txt	/*:VerilogDisableIndentRemove*
 :VerilogErrorFormat	verilog_systemverilog.txt	/*:VerilogErrorFormat*
+:VerilogFoldingAdd	verilog_systemverilog.txt	/*:VerilogFoldingAdd*
+:VerilogFoldingRemove	verilog_systemverilog.txt	/*:VerilogFoldingRemove*
 :VerilogFollowInstance	verilog_systemverilog.txt	/*:VerilogFollowInstance*
 :VerilogFollowPort	verilog_systemverilog.txt	/*:VerilogFollowPort*
 :VerilogGotoInstanceStart	verilog_systemverilog.txt	/*:VerilogGotoInstanceStart*

--- a/doc/verilog_systemverilog.txt
+++ b/doc/verilog_systemverilog.txt
@@ -267,6 +267,26 @@ COMMANDS                                                    *verilog-commands*
     configured tool is executed with |:make|. For more information check the
     |quickfix| help page.
 
+:VerilogFoldingAdd                                        *:VerilogFoldingAdd*
+:VerilogFoldingRemove                                  *:VerilogFoldingRemove*
+    Commands with auto-completion to simplify maintenance of
+    |g:verilog_syntax_fold|.
+
+    If |c_CTRL-D| is used after these commands a list of valid values is
+    suggested. When adding new values only valid and not already enabled
+    options are suggested. When removing values only currently enabled values
+    are suggested.
+
+:VerilogDisableIndentAdd                            *:VerilogDisableIndentAdd*
+:VerilogDisableIndentRemove                      *:VerilogDisableIndentRemove*
+    Commands with auto-completion to simplify maintenance of
+    |g:verilog_disable_indent|.
+
+    If |c_CTRL-D| is used after these commands a list of valid values is
+    suggested. When adding new values only valid and not already enabled
+    options are suggested. When removing values only currently enabled values
+    are suggested.
+
 ------------------------------------------------------------------------------
 KEY MAPPINGS                                                    *verilog-keys*
 
@@ -420,6 +440,9 @@ Example:
                c ;
 <
 
+    Note: The commands |:VerilogIndentAdd| and |:VerilogIndentRemove| are
+    provided to allow an easier management of this variable.
+
 ------------------------------------------------------------------------------
 SYNTAX CONFIGURATION                                   *verilog-config-syntax*
 
@@ -453,6 +476,9 @@ Example:
 >
     let g:verilog_syntax_fold = "function,task"
 <
+
+    Note: The commands |:VerilogFoldingAdd| and |:VerilogFoldingRemove| are
+    provided to allow an easier management of this variable.
 
 ------------------------------------------------------------------------------
 GENERAL CONFIGURATION                                 *verilog-config-general*

--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -5,6 +5,18 @@ command! -nargs=* VerilogErrorFormat call verilog_systemverilog#VerilogErrorForm
 command!          VerilogFollowInstance call verilog_systemverilog#FollowInstanceTag(line('.'), col('.'))
 command!          VerilogFollowPort call verilog_systemverilog#FollowInstanceSearchWord(line('.'), col('.'))
 command!          VerilogGotoInstanceStart call verilog_systemverilog#GotoInstanceStart(line('.'), col('.'))
+command! -nargs=+ -complete=customlist,verilog_systemverilog#CompleteCommand
+            \ VerilogFoldingAdd
+            \ call verilog_systemverilog#PushToVariable('g:verilog_syntax_fold', '<args>')
+command! -nargs=+ -complete=customlist,verilog_systemverilog#CompleteCommand
+            \ VerilogFoldingRemove
+            \ call verilog_systemverilog#PopFromVariable('g:verilog_syntax_fold', '<args>')
+command! -nargs=+ -complete=customlist,verilog_systemverilog#CompleteCommand
+            \ VerilogDisableIndentAdd
+            \ call verilog_systemverilog#PushToVariable('g:verilog_disable_indent', '<args>')
+command! -nargs=+ -complete=customlist,verilog_systemverilog#CompleteCommand
+            \ VerilogDisableIndentRemove
+            \ call verilog_systemverilog#PopFromVariable('g:verilog_disable_indent', '<args>')
 
 " Configure tagbar
 " This requires a recent version of universal-ctags


### PR DESCRIPTION
The following commands are provided, together with their respective
"tab completion" functions:
- `:VerilogFoldingAdd`
- `:VerilogFoldingRemove`
- `:VerilogDisableIndentAdd`
- `:VerilogDisableIndentRemove`
