### PR TITLE
Indent: Indent current line when `;` is written in insert mode

### DIFF
--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -27,6 +27,7 @@ setlocal indentkeys+==endmodule,=endfunction,=endtask,=endspecify
 setlocal indentkeys+==endclass,=endpackage,=endsequence,=endclocking
 setlocal indentkeys+==endinterface,=endgroup,=endprogram,=endproperty
 setlocal indentkeys+==`else,=`endif
+setlocal indentkeys+=;
 
 let s:vlog_open_statement = '\(\<or\>\|[<>:!=?&|^%/*+-]\)'
 let s:vlog_comment        = '\(//.*\|/\*.*\*/\)'


### PR DESCRIPTION
This guarantees that the following is correctly indented if written in sequence:

``` systemverilog
module name(
  );
```
