### PR TITLE
Syntax: Refactor to remove code duplication for syntax regions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+test-efm.log
+test-syntax.log
+test/syntax.sv.new.html

--- a/doc/tags
+++ b/doc/tags
@@ -19,6 +19,7 @@ g:verilog_efm_quickfix_clean	verilog_systemverilog.txt	/*g:verilog_efm_quickfix_
 g:verilog_efm_uvm_lst	verilog_systemverilog.txt	/*g:verilog_efm_uvm_lst*
 g:verilog_indent_assign_fix	verilog_systemverilog.txt	/*g:verilog_indent_assign_fix*
 g:verilog_indent_width	verilog_systemverilog.txt	/*g:verilog_indent_width*
+g:verilog_quick_syntax	verilog_systemverilog.txt	/*g:verilog_quick_syntax*
 g:verilog_syntax_fold_lst	verilog_systemverilog.txt	/*g:verilog_syntax_fold_lst*
 g:verilog_verbose	verilog_systemverilog.txt	/*g:verilog_verbose*
 verilog-about	verilog_systemverilog.txt	/*verilog-about*

--- a/doc/verilog_systemverilog.txt
+++ b/doc/verilog_systemverilog.txt
@@ -448,6 +448,19 @@ Example:
     Note: The commands |:VerilogFoldingAdd| and |:VerilogFoldingRemove| are
     provided to allow an easier management of this variable.
 
+                                                      *g:verilog_quick_syntax*
+g:verilog_quick_syntax~
+Default: undefined
+
+    When enabled, syntax regions will not be defined with Vim's 'syntax'
+    command. This can help performance if you are using an old machine or
+    viewing a large file such as a netlist. This can be useful if you don't
+    care about automatic indentation but still wish to have syntax coloring.
+
+    WARNING: Enabling this will change the behaviour of indentation as the
+    indentation script uses the syntax regions to determine the nested
+    context.
+
 ------------------------------------------------------------------------------
 ERROR FORMAT CONFIGURATION                                *verilog-config-efm*
 

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -186,22 +186,27 @@ for name in ['class', 'clocking', 'covergroup', 'function', 'interface',
         let s:region_end = '\<end'.name.'\>'
     endif
 
-    let s:verilog_syn_region_cmd =
-        \  'syn region verilog_'.substitute(name, '.*', '\u&', '')
-        \ .' matchgroup=verilogStatement'
-        \ .' start="'.s:region_start.'"'
-        \ .' end="'.s:region_end.'"'
-        \ .' transparent'
+    if verilog_systemverilog#VariableExists('verilog_quick_syntax')
+        execute 'syn match verilogStatement "'.s:region_start.'"'
+        execute 'syn match verilogStatement "'.s:region_end.'"'
+    else
+        let s:verilog_syn_region_cmd =
+            \  'syn region verilog'.substitute(name, '.*', '\u&', '')
+            \ .' matchgroup=verilogStatement'
+            \ .' start="'.s:region_start.'"'
+            \ .' end="'.s:region_end.'"'
+            \ .' transparent'
 
-    if name != 'class'
-        let s:verilog_syn_region_cmd .= ' keepend'
+        if name != 'class'
+            let s:verilog_syn_region_cmd .= ' keepend'
+        endif
+
+        if index(s:verilog_syntax_fold, name) >= 0 || index(s:verilog_syntax_fold, "all") >= 0
+            let s:verilog_syn_region_cmd .= ' fold'
+        endif
+
+        execute s:verilog_syn_region_cmd
     endif
-
-    if index(s:verilog_syntax_fold, name) >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-        let s:verilog_syn_region_cmd .= ' fold'
-    endif
-
-    execute s:verilog_syn_region_cmd
 endfor
 
 if index(s:verilog_syntax_fold, "block_nested") >= 0 || index(s:verilog_syntax_fold, "block_named") >= 0

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -150,110 +150,60 @@ endif
 syn keyword verilogObject      super
 syn match   verilogObject      "\<\w\+\ze\(::\|\.\)" contains=verilogNumber
 
+let s:verilog_function_task_dequalifier =
+    \  '\('
+    \ .    '\('
+    \ .        'extern\s\+\(\(pure\s\+\)\?virtual\s\+\)\?'
+    \ .        '\|'
+    \ .        'pure\s\+virtual\s\+'
+    \ .    '\)'
+    \ .    '\(\(static\|protected\|local\)\s\+\)\?'
+    \ .'\)'
+
+execute 'syn match verilogStatement "'.s:verilog_function_task_dequalifier.'\@<=\<\(task\|function\)\>"'
+
+syn match verilogStatement '\(typedef\s\+\)\@<=\<class\>'
+
 " Only enable folding if verilog_syntax_fold_lst is defined
 let s:verilog_syntax_fold=verilog_systemverilog#VariableGetValue("verilog_syntax_fold_lst")
 
-if index(s:verilog_syntax_fold, "task") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\(\(\(extern\s\+\(\(pure\s\+\)\?virtual\s\+\)\?\)\|\(\pure\s\+virtual\s\+\)\)\(\(static\|protected\|local\)\s\+\)\?\)\@<!\<task\>"
-        \ end="\<endtask\>"
-        \ transparent
-        \ keepend
-        \ fold
-    syn match   verilogStatement "\(\(\(extern\s\+\(\(pure\s\+\)\?virtual\s\+\)\?\)\|\(\pure\s\+virtual\s\+\)\)\(\(static\|protected\|local\)\s\+\)\?\)\@<=\<task\>"
-else
-    syn keyword verilogStatement  task endtask
-endif
-if index(s:verilog_syntax_fold, "function") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\(\(\(extern\s\+\(\(pure\s\+\)\?virtual\s\+\)\?\)\|\(\pure\s\+virtual\s\+\)\)\(\(static\|protected\|local\)\s\+\)\?\)\@<!\<function\>"
-        \ end="\<endfunction\>"
-        \ transparent
-        \ keepend
-        \ fold
-    syn match   verilogStatement "\(\(\(extern\s\+\(\(pure\s\+\)\?virtual\s\+\)\?\)\|\(\pure\s\+virtual\s\+\)\)\(\(static\|protected\|local\)\s\+\)\?\)\@<=\<function\>"
-else
-    syn keyword verilogStatement  function endfunction
-endif
-if index(s:verilog_syntax_fold, "class") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\(typedef\s\+\)\@<!\<\(interface\s\+\)\?class\>"
-        \ end="\<endclass\>"
-        \ transparent
-        \ fold
-    syn match   verilogStatement "\(typedef\s\+\)\@<=\<class\>"
-else
-    syn keyword verilogStatement class endclass
-endif
-if index(s:verilog_syntax_fold, "interface") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\<interface\>\(\s\+class\)\@!"
-        \ end="\<endinterface\>"
-        \ transparent
-        \ keepend
-        \ fold
-else
-    syn keyword verilogStatement interface endinterface
-endif
-if index(s:verilog_syntax_fold, "clocking") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\<clocking\>"
-        \ end="\<endclocking\>"
-        \ transparent
-        \ keepend
-        \ fold
-else
-    syn keyword verilogStatement clocking endclocking
-endif
-if index(s:verilog_syntax_fold, "covergroup") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\<covergroup\>"
-        \ end="\<endgroup\>"
-        \ transparent
-        \ keepend
-        \ fold
-else
-    syn keyword verilogStatement  covergroup endgroup
-endif
-if index(s:verilog_syntax_fold, "sequence") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\<sequence\>"
-        \ end="\<endsequence\>"
-        \ transparent
-        \ keepend
-        \ fold
-else
-    syn keyword verilogStatement  sequence endsequence
-endif
-if index(s:verilog_syntax_fold, "property") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\<property\>"
-        \ end="\<endproperty\>"
-        \ transparent
-        \ keepend
-        \ fold
-else
-    syn keyword verilogStatement  property endproperty
-endif
-if index(s:verilog_syntax_fold, "specify") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region  verilogFold
-        \ matchgroup=verilogStatement
-        \ start="\<specify\>"
-        \ end="\<endspecify\>"
-        \ transparent
-        \ keepend
-        \ fold
-else
-    syn keyword verilogStatement  specify endspecify
-endif
+for name in ['class', 'clocking', 'covergroup', 'function', 'interface',
+    \ 'property', 'sequence', 'specify', 'task', ]
+
+    if name == 'task' || name == 'function'
+        let s:region_start = s:verilog_function_task_dequalifier.'\@<!\<'.name.'\>'
+    elseif name == 'class'
+        let s:region_start = '\(typedef\s\+\)\@<!\<\(interface\s\+\)\?class\>'
+    elseif name == 'interface'
+        let s:region_start = '\<interface\>\(\s\+class\)\@!'
+    else
+        let s:region_start = '\<'.name.'\>'
+    endif
+
+    if name == 'covergroup'
+        let s:region_end = '\<endgroup\>'
+    else
+        let s:region_end = '\<end'.name.'\>'
+    endif
+
+    let s:verilog_syn_region_cmd =
+        \  'syn region verilog_'.substitute(name, '.*', '\u&', '')
+        \ .' matchgroup=verilogStatement'
+        \ .' start="'.s:region_start.'"'
+        \ .' end="'.s:region_end.'"'
+        \ .' transparent'
+
+    if name != 'class'
+        let s:verilog_syn_region_cmd .= ' keepend'
+    endif
+
+    if index(s:verilog_syntax_fold, name) >= 0 || index(s:verilog_syntax_fold, "all") >= 0
+        let s:verilog_syn_region_cmd .= ' fold'
+    endif
+
+    execute s:verilog_syn_region_cmd
+endfor
+
 if index(s:verilog_syntax_fold, "block_nested") >= 0 || index(s:verilog_syntax_fold, "block_named") >= 0
     syn region verilogFoldBlockContainer
         \ start="\<begin\>"
@@ -298,6 +248,7 @@ elseif index(s:verilog_syntax_fold, "block") >= 0 || index(s:verilog_syntax_fold
 else
     syn keyword verilogStatement  begin end
 endif
+
 if index(s:verilog_syntax_fold, "define") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
     syn region verilogFoldIfContainer
         \ start="`ifn\?def\>"
@@ -331,23 +282,23 @@ if index(s:verilog_syntax_fold, "define") >= 0 || index(s:verilog_syntax_fold, "
         \ contained containedin=verilogFoldIfContainer
         \ contains=TOP
 endif
+
 if index(s:verilog_syntax_fold, "instance") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
     syn region verilogFold
         \ start="^\s*\w\+\(\s*#\s*(\|\s\+\w\+\s*(\)\(.*)\s*\w\+\s*;\)\@!"
         \ end=")\s*;"
         \ transparent
-        \ fold
         \ keepend
+        \ fold
 endif
 
 " Expand verilogComment
 if len(s:verilog_syntax_fold) > 0
-    syn clear   verilogComment
-    syn match   verilogComment  "//.*"                      contains=verilogTodo,@Spell
+    syn match verilogComment "//.*" contains=verilogTodo,@Spell
     if index(s:verilog_syntax_fold, "comment") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-        syn region  verilogComment  start="/\*"     end="\*/"   contains=verilogTodo,@Spell                     keepend fold
+        syn region verilogComment start="/\*" end="\*/" contains=verilogTodo,@Spell keepend fold
     else
-        syn region  verilogComment  start="/\*"     end="\*/"   contains=verilogTodo,@Spell                     keepend
+        syn region verilogComment start="/\*" end="\*/" contains=verilogTodo,@Spell keepend
     endif
 endif
 

--- a/test/folding.v
+++ b/test/folding.v
@@ -28,42 +28,46 @@ endtask : t                                                   //<1><1><1>
 *                                                             //<1><1><1>
 */                                                            //<1><1><1>
                                                               //<0><0><0>
-extern function ext_func (x, y);                              //<0><0><0>
+extern                        function    e_func (x, y);      //<0><0><0>
+extern              static    function   es_func (x, y);      //<0><0><0>
+extern              protected function   ep_func (x, y);      //<0><0><0>
+extern              local     function   el_func (x, y);      //<0><0><0>
                                                               //<0><0><0>
-extern static function ext_static_func (x, y);                //<0><0><0>
+       pure virtual           function   pv_func (x);         //<0><0><0>
+       pure virtual static    function  pvs_func (x);         //<0><0><0>
+       pure virtual protected function  pvp_func (x);         //<0><0><0>
+       pure virtual local     function  pvl_func (x);         //<0><0><0>
                                                               //<0><0><0>
-extern protected function ext_protected_func (x, y);          //<0><0><0>
+extern      virtual           function   ev_func (x);         //<0><0><0>
+extern      virtual static    function  evs_func (x);         //<0><0><0>
+extern      virtual protected function  evp_func (x);         //<0><0><0>
+extern      virtual local     function  evl_func (x);         //<0><0><0>
                                                               //<0><0><0>
-extern local function ext_local_func (x, y);                  //<0><0><0>
+extern pure virtual           function  epv_func (x);         //<0><0><0>
+extern pure virtual static    function epvs_func (x);         //<0><0><0>
+extern pure virtual protected function epvp_func (x);         //<0><0><0>
+extern pure virtual local     function epvl_func (x);         //<0><0><0>
                                                               //<0><0><0>
-extern pure virtual function ext_pure_virt_func (x);          //<0><0><0>
+extern                        task        e_task (x, y);      //<0><0><0>
+extern              static    task       es_task (x, y);      //<0><0><0>
+extern              protected task       ep_task (x, y);      //<0><0><0>
+extern              local     task       el_task (x, y);      //<0><0><0>
                                                               //<0><0><0>
-pure virtual function pure_virt_func (x);                     //<0><0><0>
+       pure virtual           task       pv_task (x);         //<0><0><0>
+       pure virtual static    task      pvs_task (x);         //<0><0><0>
+       pure virtual protected task      pvp_task (x);         //<0><0><0>
+       pure virtual local     task      pvl_task (x);         //<0><0><0>
                                                               //<0><0><0>
-pure virtual static function pure_virt_static_func (x);       //<0><0><0>
+extern      virtual           task       ev_task (x, y);      //<0><0><0>
+extern      virtual static    task      evs_task (x, y);      //<0><0><0>
+extern      virtual protected task      evp_task (x, y);      //<0><0><0>
+extern      virtual local     task      evl_task (x, y);      //<0><0><0>
                                                               //<0><0><0>
-pure virtual protected function pure_virt_protected_func (x); //<0><0><0>
+extern pure virtual           task      epv_task (x, y);      //<0><0><0>
+extern pure virtual static    task     epvs_task (x, y);      //<0><0><0>
+extern pure virtual protected task     epvp_task (x, y);      //<0><0><0>
+extern pure virtual local     task     epvl_task (x, y);      //<0><0><0>
                                                               //<0><0><0>
-pure virtual local function pure_virt_local_func (x);         //<0><0><0>
-                                                              //<0><0><0>
-                                                              //<0><0><0>
-extern task ext_task (x, y);                                  //<0><0><0>
-                                                              //<0><0><0>
-extern static task ext_static_task (x, y);                    //<0><0><0>
-                                                              //<0><0><0>
-extern protected task ext_protected_task (x, y);              //<0><0><0>
-                                                              //<0><0><0>
-extern local task ext_local_task (x, y);                      //<0><0><0>
-                                                              //<0><0><0>
-extern pure virtual task ext_pure_virt_task (x);              //<0><0><0>
-                                                              //<0><0><0>
-pure virtual task pure_virt_task (x);                         //<0><0><0>
-                                                              //<0><0><0>
-pure virtual static task pure_virt_static_task (x);           //<0><0><0>
-                                                              //<0><0><0>
-pure virtual protected task pure_virt_protected_task (x);     //<0><0><0>
-                                                              //<0><0><0>
-pure virtual local task pure_virt_local_task (x);             //<0><0><0>
                                                               //<0><0><0>
 /**                                                           //<1><1><1>
 * Static function                                             //<1><1><1>

--- a/test/run_test.vim
+++ b/test/run_test.vim
@@ -119,6 +119,8 @@ endfunction
 " Syntax test
 "-----------------------------------------------------------------------
 function! RunTestSyntax()
+    let g:verilog_syntax_fold_lst=""
+    colorscheme default
     set nomore "Disable pager to avoid issues with Travis
 
     silent view test/syntax.sv
@@ -142,6 +144,9 @@ function! RunTestSyntax()
         echo 'Syntax test passed'
         let test_result = 0
     else
+        echo '=====DIFF START====='
+        echo output
+        echo '=====DIFF END======='
         echo 'Syntax test failed'
         let test_result = 1
     endif

--- a/test/syntax.sv
+++ b/test/syntax.sv
@@ -28,8 +28,6 @@ casez
 cell
 chandle
 checker
-class
-clocking
 cmos
 config
 const
@@ -37,8 +35,6 @@ constraint
 context
 continue
 cover
-covergroup
-endgroup
 coverpoint
 cross
 deassign
@@ -52,11 +48,8 @@ edge
 else
 endcase
 endchecker
-endclass
-endclocking
 endconfig
 endgenerate
-endinterface
 endmodule
 endpackage
 endprimitive
@@ -77,8 +70,6 @@ foreach
 forever
 fork
 forkjoin
-function
-endfunction
 generate
 genvar
 global
@@ -102,7 +93,6 @@ instance
 int
 integer
 interconnect
-interface
 intersect
 join
 join_any
@@ -142,8 +132,6 @@ posedge
 primitive
 priority
 program
-property
-endproperty
 protected
 pull0
 pull1
@@ -177,8 +165,6 @@ s_nexttime
 s_until
 s_until_with
 scalared
-sequence
-endsequence
 shortint
 shortreal
 showcancelled
@@ -186,8 +172,6 @@ signed
 small
 soft
 solve
-specify
-endspecify
 specparam
 static
 string
@@ -202,8 +186,6 @@ sync_accept_on
 sync_reject_on
 table
 tagged
-task
-endtask
 this
 throughout
 time
@@ -247,6 +229,25 @@ within
 wor
 xnor
 xor
+// Syntax regions
+class
+endclass
+clocking
+endclocking
+covergroup
+endgroup
+function
+endfunction
+interface
+endinterface
+property
+endproperty
+sequence
+endsequence
+specify
+endspecify
+task
+endtask
 `endif
 `ifdef TIME
 10ns

--- a/test/syntax.sv.html
+++ b/test/syntax.sv.html
@@ -30,8 +30,6 @@
 <span class="Statement">cell</span>
 <span class="Statement">chandle</span>
 <span class="Statement">checker</span>
-<span class="Statement">class</span>
-<span class="Statement">clocking</span>
 <span class="Statement">cmos</span>
 <span class="Statement">config</span>
 <span class="Statement">const</span>
@@ -39,8 +37,6 @@
 <span class="Statement">context</span>
 <span class="Statement">continue</span>
 <span class="Statement">cover</span>
-<span class="Statement">covergroup</span>
-<span class="Statement">endgroup</span>
 <span class="Statement">coverpoint</span>
 <span class="Statement">cross</span>
 <span class="Statement">deassign</span>
@@ -54,11 +50,8 @@
 <span class="Statement">else</span>
 <span class="Statement">endcase</span>
 <span class="Statement">endchecker</span>
-<span class="Statement">endclass</span>
-<span class="Statement">endclocking</span>
 <span class="Statement">endconfig</span>
 <span class="Statement">endgenerate</span>
-<span class="Statement">endinterface</span>
 <span class="Statement">endmodule</span>
 <span class="Statement">endpackage</span>
 <span class="Statement">endprimitive</span>
@@ -79,8 +72,6 @@
 <span class="Statement">forever</span>
 <span class="Statement">fork</span>
 <span class="Statement">forkjoin</span>
-<span class="Statement">function</span>
-<span class="Statement">endfunction</span>
 <span class="Statement">generate</span>
 <span class="Statement">genvar</span>
 <span class="Statement">global</span>
@@ -104,7 +95,6 @@
 <span class="Statement">int</span>
 <span class="Statement">integer</span>
 <span class="Statement">interconnect</span>
-<span class="Statement">interface</span>
 <span class="Statement">intersect</span>
 <span class="Statement">join</span>
 <span class="Statement">join_any</span>
@@ -144,8 +134,6 @@
 <span class="Statement">primitive</span>
 <span class="Statement">priority</span>
 <span class="Statement">program</span>
-<span class="Statement">property</span>
-<span class="Statement">endproperty</span>
 <span class="Statement">protected</span>
 <span class="Statement">pull0</span>
 <span class="Statement">pull1</span>
@@ -179,8 +167,6 @@
 <span class="Statement">s_until</span>
 <span class="Statement">s_until_with</span>
 <span class="Statement">scalared</span>
-<span class="Statement">sequence</span>
-<span class="Statement">endsequence</span>
 <span class="Statement">shortint</span>
 <span class="Statement">shortreal</span>
 <span class="Statement">showcancelled</span>
@@ -188,8 +174,6 @@
 <span class="Statement">small</span>
 <span class="Statement">soft</span>
 <span class="Statement">solve</span>
-<span class="Statement">specify</span>
-<span class="Statement">endspecify</span>
 <span class="Statement">specparam</span>
 <span class="Statement">static</span>
 <span class="Statement">string</span>
@@ -204,8 +188,6 @@
 <span class="Statement">sync_reject_on</span>
 <span class="Statement">table</span>
 <span class="Statement">tagged</span>
-<span class="Statement">task</span>
-<span class="Statement">endtask</span>
 <span class="Statement">this</span>
 <span class="Statement">throughout</span>
 <span class="Statement">time</span>
@@ -249,6 +231,25 @@
 <span class="Statement">wor</span>
 <span class="Statement">xnor</span>
 <span class="Statement">xor</span>
+<span class="Comment">// Syntax regions</span>
+<span class="Statement">class</span>
+<span class="Statement">endclass</span>
+<span class="Statement">clocking</span>
+<span class="Statement">endclocking</span>
+<span class="Statement">covergroup</span>
+<span class="Statement">endgroup</span>
+<span class="Statement">function</span>
+<span class="Statement">endfunction</span>
+<span class="Statement">interface</span>
+<span class="Statement">endinterface</span>
+<span class="Statement">property</span>
+<span class="Statement">endproperty</span>
+<span class="Statement">sequence</span>
+<span class="Statement">endsequence</span>
+<span class="Statement">specify</span>
+<span class="Statement">endspecify</span>
+<span class="Statement">task</span>
+<span class="Statement">endtask</span>
 <span class="PreProc">`endif</span>
 <span class="PreProc">`ifdef</span> <span class="Constant">TIME</span>
 <span class="Constant">10ns</span>


### PR DESCRIPTION
-Renamed each region from VerilogFold -> Verilog{name}, e.g. VerilogFunction.

-Tidied up complicated regex for matching function/task statements by creating a
dequalifier variable.

-Syntax regions are now always defined. Before regions were only defined if
folding was enabled.

-Updated syntax test.

-Clear fold config and set default colorscheme for syntax test.
