### PR TITLE
Efm/compiler

### DIFF
--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -704,9 +704,10 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
 
   if (l:tool == "vcs")
     " Error messages
-    set errorformat=%E%trror-\[%.%\\+\]\ %m
+    set errorformat=%EError-\[%.%\\+\]\ %m
     set errorformat+=%C%m\"%f\"\\,\ %l%.%#
     set errorformat+=%C%f\\,\ %l
+    set errorformat+=%C%\\s%\\+%l:\ %m\\,\ column\ %c
     set errorformat+=%C%\\s%\\+%l:\ %m
     set errorformat+=%C%m\"%f\"\\,%.%#
     set errorformat+=%Z%p^                      "Column pointer
@@ -714,9 +715,9 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
     set errorformat+=%Z%m                       "Finalization messages
     " Warning messages
     if (l:mode <= 2)
-      set errorformat+=%W%tarning-\[%.%\\+]\\$
-      set errorformat+=%-W%tarning-[LCA_FEATURES_ENABLED]\ Usage\ warning    "Ignore LCA enabled warning
-      set errorformat+=%W%tarning-\[%.%\\+\]\ %m
+      set errorformat+=%WWarning-\[%.%\\+]\\$
+      set errorformat+=%-WWarning-[LCA_FEATURES_ENABLED]\ Usage\ warning    "Ignore LCA enabled warning
+      set errorformat+=%WWarning-\[%.%\\+\]\ %m
     endif
     " Lint message
     if (l:mode <= 1)

--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -650,6 +650,7 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
           \"5. Leda",
           \"6. Verilator",
           \"7. NCVerilog",
+          \"8. SpyGlass",
           \])
     echo "\n"
     if (l:tool == 1)
@@ -667,7 +668,7 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
     elseif (l:tool == 7)
       let l:tool = "ncverilog"
     else
-      let l:tool = "iverilog"
+      let l:tool = "spyglass"
     endif
   else
     let l:tool = tolower(a:1)
@@ -686,7 +687,8 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
       \ l:tool == "msim" ||
       \ l:tool == "cver" ||
       \ l:tool == "verilator" ||
-      \ l:tool == "ncverilog"
+      \ l:tool == "ncverilog" ||
+      \ l:tool == "spyglass"
       \ )
       let l:mode = inputlist([
             \"1. check all",
@@ -713,7 +715,7 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
 
   call verilog_systemverilog#Verbose("Configuring errorformat with: tool=" . l:tool . "; mode=" . l:mode)
 
-  if (index(['vcs', 'modelsim', 'iverilog', 'cver', 'leda', 'verilator', 'ncverilog'], l:tool) >= 0)
+  if (index(['vcs', 'modelsim', 'iverilog', 'cver', 'leda', 'verilator', 'ncverilog', 'spyglass'], l:tool) >= 0)
     execute 'compiler! '. l:tool
     echo 'Selected errorformat for "' . l:tool . '"'
   else

--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -637,7 +637,7 @@ endfunction
 " }}}
 
 "------------------------------------------------------------------------
-" Definitions for errorformat
+" Command to control errorformat and compiler
 " {{{
 function! verilog_systemverilog#VerilogErrorFormat(...)
   " Choose tool
@@ -648,7 +648,7 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
           \"3. iverilog",
           \"4. cver",
           \"5. Leda",
-          \"6. verilator",
+          \"6. Verilator",
           \"7. NCVerilog",
           \])
     echo "\n"
@@ -693,6 +693,9 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
             \"2. ignore warnings"
             \])
       echo "\n"
+      if (l:mode == 2)
+        let l:mode = 3
+      endif
     else
       let l:mode = 1
     endif
@@ -700,108 +703,21 @@ function! verilog_systemverilog#VerilogErrorFormat(...)
     let l:mode = a:2
   endif
 
+  if (l:mode <= 1)
+    let g:verilog_efm_level = "lint"
+  elseif (l:mode <= 2)
+    let g:verilog_efm_level = "warning"
+  else
+    let g:verilog_efm_level = "error"
+  endif
+
   call verilog_systemverilog#Verbose("Configuring errorformat with: tool=" . l:tool . "; mode=" . l:mode)
 
-  if (l:tool == "vcs")
-    " Error messages
-    set errorformat=%EError-\[%.%\\+\]\ %m
-    set errorformat+=%C%m\"%f\"\\,\ %l%.%#
-    set errorformat+=%C%f\\,\ %l
-    set errorformat+=%C%\\s%\\+%l:\ %m\\,\ column\ %c
-    set errorformat+=%C%\\s%\\+%l:\ %m
-    set errorformat+=%C%m\"%f\"\\,%.%#
-    set errorformat+=%Z%p^                      "Column pointer
-    set errorformat+=%C%m                       "Catch all rule
-    set errorformat+=%Z%m                       "Finalization messages
-    " Warning messages
-    if (l:mode <= 2)
-      set errorformat+=%WWarning-\[%.%\\+]\\$
-      set errorformat+=%-WWarning-[LCA_FEATURES_ENABLED]\ Usage\ warning    "Ignore LCA enabled warning
-      set errorformat+=%WWarning-\[%.%\\+\]\ %m
-    endif
-    " Lint message
-    if (l:mode <= 1)
-      set errorformat+=%I%tint-\[%.%\\+\]\ %m
-    endif
-    echo "Selected VCS errorformat"
-    "TODO Add support for:
-    "Error-[SE] Syntax error
-    "  Following verilog source has syntax error :
-    "  "../../rtl_v/anadigintf/anasoftramp.v", 128: token is 'else'
-    "          else
-  endif
-  if (l:tool == "msim")
-    " Error messages
-    set errorformat=\*\*\ Error:\ %f(%l):\ %m
-    " Warning messages
-    if (l:mode <= 1)
-      set errorformat+=\*\*\ Warning:\ \[\%n\]\ %f(%l):\ %m
-    endif
-    echo "Selected Modelsim errorformat"
-  endif
-  if (l:tool == "iverilog")
-    set errorformat=%f\\:%l:\ %m
-    echo "Selected iverilog errorformat"
-  endif
-  if (l:tool == "cver")
-    " Error messages
-    set errorformat=\*\*%f(%l)\ ERROR\*\*\ \[%n\]\ %m
-    " Warning messages
-    if (l:mode <= 1)
-      set errorformat+=\*\*%f(%l)\ WARN\*\*\ \[%n\]\ %m,\*\*\ WARN\*\*\ \[\%n\]\ %m
-    endif
-    echo "Selected cver errorformat"
-  endif
-  if (l:tool == "leda")
-    " Simple errorformat:
-    set errorformat=%f\\:%l:\ %.%#\[%t%.%#\]\ %m
-    "TODO Review -> Multiple line errorformat:
-    "set errorformat=%A\ %#%l:%.%#,%C\ \ \ \ \ \ \ \ %p^^%#,%Z%f:%l:\ %.%#[%t%.%#]\ %m
-    echo "Selected Leda errorformat"
-  endif
-  if (l:tool == "verilator")
-    set errorformat=%%%trror%.%#:\ %f:%l:\ %m
-    if (l:mode <= 1)
-      set errorformat+=%%%tarning%.%#:\ %f:%l:\ %m
-    "elseif (l:mode <= 1)
-    endif
-    echo "Selected Verilator errorformat"
-  endif
-  if (l:tool == "ncverilog")
-    " Based on https://github.com/vhda/verilog_systemverilog.vim/issues/88
-    set errorformat =%.%#:\ *%t\\,%.%#\ %#\(%f\\,%l\|%c\):\ %m
-    set errorformat+=%.%#:\ *%t\\,%.%#\ %#\(%f\\,%l\):\ %m
-    " Multi-line error messages
-    set errorformat+=%A%.%#\ *%t\\,%.%#:\ %m,%ZFile:\ %f\\,\ line\ =\ %l\\,\ pos\ =\ %c
-    if (l:mode > 1)
-      " Ignore warnings
-      set errorformat^=%-G%.%#\ *W\\,%.%#:\ %m
-    endif
-    echo "Selected NCVerilog errorformat"
-  endif
-  " Append UVM errorformat if enabled
-  if (exists("g:verilog_efm_uvm_lst"))
-    let verilog_efm_uvm = verilog_systemverilog#VariableGetValue('verilog_efm_uvm_lst')
-    if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'info') >= 0)
-      set errorformat+=UVM_%tNFO\ %f(%l)\ %m
-    endif
-    if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'warning') >= 0)
-      set errorformat+=UVM_%tARNING\ %f(%l)\ %m
-    endif
-    if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'error') >= 0)
-      set errorformat+=UVM_%tRROR\ %f(%l)\ %m
-    endif
-    if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'fatal') >= 0)
-      set errorformat+=UVM_%tATAL\ %f(%l)\ %m
-    endif
-  endif
-  " Append any user-defined efm entries
-  if (exists("g:verilog_efm_custom"))
-    set errorformat+=g:verilog_efm_custom
-  endif
-  " Remove all unmatched lines from the quickfix window
-  if (exists("g:verilog_efm_quickfix_clean"))
-    set errorformat+=%-G%.%#
+  if (index(['vcs', 'modelsim', 'iverilog', 'cver', 'leda', 'verilator', 'ncverilog'], l:tool) >= 0)
+    execute 'compiler! '. l:tool
+    echo 'Selected errorformat for "' . l:tool . '"'
+  else
+    echoerr 'Unknown tool name "' . l:tool . '"'
   endif
 endfunction
 " }}}

--- a/compiler/cver.vim
+++ b/compiler/cver.vim
@@ -1,0 +1,31 @@
+" Vim compiler file
+" Compiler: GPL cver
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "cver"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+CompilerSet errorformat=\*\*%f(%l)\ ERROR\*\*\ \[%n\]\ %m
+
+" Warning level formats
+if (!exists("g:verilog_efm_level") || g:verilog_efm_level != "error")
+  CompilerSet errorformat+=\*\*%f(%l)\ WARN\*\*\ \[%n\]\ %m
+  CompilerSet errorformat+=\*\*\ WARN\*\*\ \[\%n\]\ %m
+endif
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/iverilog.vim
+++ b/compiler/iverilog.vim
@@ -1,0 +1,25 @@
+" Vim compiler file
+" Compiler: Icarus Verilog
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "iverilog"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+CompilerSet errorformat=%f\\:%l:\ %m
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/leda.vim
+++ b/compiler/leda.vim
@@ -1,0 +1,25 @@
+" Vim compiler file
+" Compiler: Synopsys Leda
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "leda"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+CompilerSet errorformat=%f\\:%l:\ %.%#\[%t%.%#\]\ %m
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/msim.vim
+++ b/compiler/msim.vim
@@ -1,0 +1,30 @@
+" Vim compiler file
+" Compiler: Mentor Modelsim
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "msim"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+CompilerSet errorformat=\*\*\ Error:\ %f(%l):\ %m
+
+" Warning level formats
+if (!exists("g:verilog_efm_level") || g:verilog_efm_level != "error")
+  CompilerSet errorformat+=\*\*\ Warning:\ \[\%n\]\ %f(%l):\ %m
+endif
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/ncverilog.vim
+++ b/compiler/ncverilog.vim
@@ -1,0 +1,34 @@
+" Vim compiler file
+" Compiler: Cadence NCVerilog
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "ncverilog"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+" Based on https://github.com/vhda/verilog_systemverilog.vim/issues/88
+CompilerSet errorformat =%.%#:\ *%t\\,%.%#\ %#\(%f\\,%l\|%c\):\ %m
+CompilerSet errorformat+=%.%#:\ *%t\\,%.%#\ %#\(%f\\,%l\):\ %m
+" Multi-line error messages
+CompilerSet errorformat+=%A%.%#\ *%t\\,%.%#:\ %m,%ZFile:\ %f\\,\ line\ =\ %l\\,\ pos\ =\ %c
+
+" Ignore Warning level formats
+if (!exists("g:verilog_efm_level") || g:verilog_efm_level == "error")
+  CompilerSet errorformat^=%-G%.%#\ *W\\,%.%#:\ %m
+endif
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/spyglass.vim
+++ b/compiler/spyglass.vim
@@ -1,0 +1,32 @@
+" Vim compiler file
+" Compiler: Synopsys Spyglass
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "spyglass"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+CompilerSet errorformat =%.%#\ %\\+%tATAL\ %\\+%[a-zA-Z0-9]%\\+\ %\\+%f\ %\\+%l\ %\\+%n\ %\\+%m
+CompilerSet errorformat+=%.%#\ %\\+%tRROR\ %\\+%[a-zA-Z0-9]%\\+\ %\\+%f\ %\\+%l\ %\\+%n\ %\\+%m
+CompilerSet errorformat+=%.%#\ %\\+Syntax\ %\\+%f\ %\\+%l\ %\\+%m
+
+" Warning level formats
+if (!exists("g:verilog_efm_level") || g:verilog_efm_level != "error")
+  CompilerSet errorformat+=%.%#\ %\\+%tARNING\ %\\+%[a-zA-Z0-9]%\\+\ %\\+%f\ %\\+%l\ %\\+%n\ %\\+%m
+endif
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/vcs.vim
+++ b/compiler/vcs.vim
@@ -1,0 +1,45 @@
+" Vim compiler file
+" Compiler: Synopsys VCS
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "vcs"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+CompilerSet errorformat =%EError-\[%.%\\+\]\ %m
+CompilerSet errorformat+=%C%m\"%f\"\\,\ %l%.%#
+CompilerSet errorformat+=%C%f\\,\ %l
+CompilerSet errorformat+=%C%\\s%\\+%l:\ %m\\,\ column\ %c
+CompilerSet errorformat+=%C%\\s%\\+%l:\ %m
+CompilerSet errorformat+=%C%m\"%f\"\\,%.%#
+CompilerSet errorformat+=%Z%p^                      "Column pointer
+CompilerSet errorformat+=%C%m                       "Catch all rule
+CompilerSet errorformat+=%Z%m                       "Finalization messages
+
+" Warning level formats
+if (!exists("g:verilog_efm_level") || g:verilog_efm_level != "error")
+  CompilerSet errorformat+=%WWarning-\[%.%\\+]\\$
+  CompilerSet errorformat+=%-WWarning-[LCA_FEATURES_ENABLED]\ Usage\ warning    "Ignore LCA enabled warning
+  CompilerSet errorformat+=%WWarning-\[%.%\\+\]\ %m
+endif
+
+" Lint level formats
+if (!exists("g:verilog_efm_level") || g:verilog_efm_level == "lint")
+  CompilerSet errorformat+=%I%tint-\[%.%\\+\]\ %m
+endif
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/verilator.vim
+++ b/compiler/verilator.vim
@@ -1,0 +1,30 @@
+" Vim compiler file
+" Compiler: Verilator
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "verilator"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Error level formats
+CompilerSet errorformat=%%%trror%.%#:\ %f:%l:\ %m
+
+" Warning level formats
+if (!exists("g:verilog_efm_level") || g:verilog_efm_level != "error")
+  CompilerSet errorformat+=%%%tarning%.%#:\ %f:%l:\ %m
+endif
+
+" Load common errorformat configurations
+runtime compiler/verilog_common.vim
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/compiler/verilog_common.vim
+++ b/compiler/verilog_common.vim
@@ -1,0 +1,40 @@
+" Vim compiler file
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+" Append UVM errorformat if enabled
+if (exists("g:verilog_efm_uvm_lst"))
+  let verilog_efm_uvm = verilog_systemverilog#VariableGetValue('verilog_efm_uvm_lst')
+  if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'info') >= 0)
+    CompilerSet errorformat+=UVM_%tNFO\ %f(%l)\ %m
+  endif
+  if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'warning') >= 0)
+    CompilerSet errorformat+=UVM_%tARNING\ %f(%l)\ %m
+  endif
+  if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'error') >= 0)
+    CompilerSet errorformat+=UVM_%tRROR\ %f(%l)\ %m
+  endif
+  if (index(verilog_efm_uvm, 'all') >= 0 || index(verilog_efm_uvm, 'fatal') >= 0)
+    CompilerSet errorformat+=UVM_%tATAL\ %f(%l)\ %m
+  endif
+endif
+
+" Append any user-defined efm entries
+if (exists("g:verilog_efm_custom"))
+  CompilerSet errorformat+=g:verilog_efm_custom
+endif
+
+" Cleanup rule
+if (exists("g:verilog_efm_quickfix_clean"))
+  CompilerSet errorformat+=%-G%.%#
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vi: sw=2 sts=2:

--- a/doc/tags
+++ b/doc/tags
@@ -15,6 +15,7 @@ b:verilog_verbose	verilog_systemverilog.txt	/*b:verilog_verbose*
 g:verilog_disable_indent_lst	verilog_systemverilog.txt	/*g:verilog_disable_indent_lst*
 g:verilog_dont_deindent_eos	verilog_systemverilog.txt	/*g:verilog_dont_deindent_eos*
 g:verilog_efm_custom	verilog_systemverilog.txt	/*g:verilog_efm_custom*
+g:verilog_efm_level	verilog_systemverilog.txt	/*g:verilog_efm_level*
 g:verilog_efm_quickfix_clean	verilog_systemverilog.txt	/*g:verilog_efm_quickfix_clean*
 g:verilog_efm_uvm_lst	verilog_systemverilog.txt	/*g:verilog_efm_uvm_lst*
 g:verilog_indent_assign_fix	verilog_systemverilog.txt	/*g:verilog_indent_assign_fix*

--- a/doc/verilog_systemverilog.txt
+++ b/doc/verilog_systemverilog.txt
@@ -151,8 +151,8 @@ To enable syntax folding set the following option:
 ------------------------------------------------------------------------------
 VERILOG ERROR FORMATS                                            *verilog-efm*
 
-This plugin includes the |'errorformat'| configurations for the following
-Verilog tools:
+This plugin includes the |:compiler| definitions for the following Verilog
+tools:
 
 * Synopsys VCS (`vcs`)
 * Mentor Modelsim (`msim`)
@@ -160,6 +160,15 @@ Verilog tools:
 * GPL Cver (`cver`)
 * Synopsys Leda (`leda`)
 * Verilator (`verilator`)
+* NCVerilog (`ncverilog`)
+
+The |:compiler| or |:compiler|! commands can be used to enable these
+definitions on the current buffer or all buffers, respectively.
+Example for `iverilog`:
+
+>
+    :compiler! iverilog
+<
 
 The command |:VerilogErrorFormat| allows the interactive selection of these
 configurations. In some cases it is also possible to ignore lint and/or
@@ -179,11 +188,14 @@ This argument can take the following values:
 2. Ignore lint messages.
 3. Ignore lint and warning messages.
 
-After the |'errorformat'| has been so defined, it is only a matter of setting
-|'makeprg'| and run `:make` to call the tool of choice and vim will
-automatically detect errors, open the required file and place the cursor on
-the error position. To navigate the error list use the commands `:cnext` and
-`:cprevious`.
+    Note: The |:compiler| definitions only configure the |'errorformat'|
+    option, so it is always necessary to also setup |'makeprg'| before running
+    |:make| to execute the selected tool.
+
+After doing this Vim will be able to detect error messages displayed by the
+selected tool. Vim will also automatically open the files with errors and
+place the cursor on the error position. To navigate the error list use the
+commands |:cnext| and |:cprevious|.
 
 For more information check the help page for the |quickfix| vim feature.
 
@@ -246,7 +258,9 @@ COMMANDS                                                    *verilog-commands*
     Configure |'errorformat'| for the selected tool.
 
     If called without arguments it will interactively ask for the tool name
-    and, if the tool supports it, the level of errors to identify in the log.
+    and, if the tool supports it, the level of error messages to identify in
+    the log. This commands then configures |g:verilog_efm_level| accordingly
+    and executes |:compiler|! with the selected tool.
 
     Values supported for {tool}:
       vcs       - Synopsys VCS
@@ -254,6 +268,7 @@ COMMANDS                                                    *verilog-commands*
       iverilog  - Icarus Verilog
       cver      - GPL Cver
       leda      - Synopsys Leda
+      verilator - Verilator
       ncverilog - Cadence NCVerilog
 
     Values supported for {level}:
@@ -451,6 +466,23 @@ Example:
 ------------------------------------------------------------------------------
 ERROR FORMAT CONFIGURATION                                *verilog-config-efm*
 
+                                                         *g:verilog_efm_level*
+g:verilog_efm_level~
+Default: undefined
+
+    Determines which types of messages are added to |'errorformat'| for
+    detection. When undefined, all messages are detected. The following values
+    are supported:
+        - `error`   - Only Error level messages are detected.
+        - `warning` - Error and Warning level messages are detected.
+        - `lint`    - All messages are detected.
+
+Example:
+
+>
+    let g:verilog_efm_level = "error"
+<
+
                                                        *g:verilog_efm_uvm_lst*
 g:verilog_efm_uvm_lst~
 Default: undefined
@@ -480,7 +512,8 @@ Default: undefined
 
     When enabled, appends global matching string to |'errorformat'| such that
     any message that does not match any preceding rule will not appear in the
-    |quickfix| window.
+    |quickfix| window. This will result in a clean quickfix window, where only
+    parsed messages are shown.
 
 Example:
 

--- a/doc/verilog_systemverilog.txt
+++ b/doc/verilog_systemverilog.txt
@@ -161,6 +161,7 @@ tools:
 * Synopsys Leda (`leda`)
 * Verilator (`verilator`)
 * NCVerilog (`ncverilog`)
+* SpyGlass (`spyglass`)
 
 The |:compiler| or |:compiler|! commands can be used to enable these
 definitions on the current buffer or all buffers, respectively.
@@ -270,6 +271,7 @@ COMMANDS                                                    *verilog-commands*
       leda      - Synopsys Leda
       verilator - Verilator
       ncverilog - Cadence NCVerilog
+      spyglass  - Synopsys SpyGlass
 
     Values supported for {level}:
       1 - Mark all messages

--- a/test/errorformat.txt
+++ b/test/errorformat.txt
@@ -26,6 +26,10 @@ ncsim: *E,SOMECADENCEERRORCODE: Message
 ncsim: *E,ASRTST (filename.sv,123|12): Reason
 ncsim: irun 11.11-s111: Started on May 11, 1111 at 11:11:11 IST
 
+### spyglass E=1, W=1
+STX_VE_481   Syntax     path/file.v   1    Syntax error near ( } )
+[66]     UndrivenNUnloaded-ML    WARNING      Warning     path/file.v    1      2    UndrivenNUnloaded-ML : Detected undriven and unloaded(unconnected) net
+
 ### UVM E=2, W=1, L=1
 UVM_FATAL /path/file.sv(5) @ 1000: text
 UVM_ERROR /path/file.sv(5) @ 1000: text

--- a/test/functions.vim
+++ b/test/functions.vim
@@ -88,6 +88,9 @@ function! TestEfm(tool, mode, search_uvm)
     let uvm_expected_warnings = 0
     let uvm_expected_lints    = 0
 
+    " Re-read test file
+    silent view test/errorformat.txt
+
     " Obtain tool configuration from file
     let config_found = 0
     let linenr = 0

--- a/test/run_test.vim
+++ b/test/run_test.vim
@@ -105,6 +105,10 @@ function! RunTestEfm()
         silent view test/errorformat.txt
         let test_result=TestEfm('ncverilog', 3, check_uvm) || test_result
         echo ''
+
+        silent view test/errorformat.txt
+        let test_result=TestEfm('spyglass', 1, check_uvm) || test_result
+        echo ''
     endfor
 
     " Check test results and exit accordingly

--- a/test/run_test.vim
+++ b/test/run_test.vim
@@ -86,29 +86,12 @@ function! RunTestEfm()
             unlet! g:verilog_efm_uvm_lst
         endif
 
-        silent view test/errorformat.txt
-        let test_result=TestEfm('iverilog', 1, check_uvm) || test_result
-        echo ''
-
-        silent view test/errorformat.txt
-        let test_result=TestEfm('verilator', 1, check_uvm) || test_result
-        echo ''
-
-        silent view test/errorformat.txt
-        let test_result=TestEfm('verilator', 3, check_uvm) || test_result
-        echo ''
-
-        silent view test/errorformat.txt
-        let test_result=TestEfm('ncverilog', 1, check_uvm) || test_result
-        echo ''
-
-        silent view test/errorformat.txt
-        let test_result=TestEfm('ncverilog', 3, check_uvm) || test_result
-        echo ''
-
-        silent view test/errorformat.txt
-        let test_result=TestEfm('spyglass', 1, check_uvm) || test_result
-        echo ''
+        let test_result = TestEfm('iverilog',  1, check_uvm) || test_result
+        let test_result = TestEfm('verilator', 1, check_uvm) || test_result
+        let test_result = TestEfm('verilator', 3, check_uvm) || test_result
+        let test_result = TestEfm('ncverilog', 1, check_uvm) || test_result
+        let test_result = TestEfm('ncverilog', 3, check_uvm) || test_result
+        let test_result = TestEfm('spyglass',  1, check_uvm) || test_result
     endfor
 
     " Check test results and exit accordingly

--- a/test/run_test.vim
+++ b/test/run_test.vim
@@ -95,7 +95,7 @@ function! RunTestEfm()
         echo ''
 
         silent view test/errorformat.txt
-        let test_result=TestEfm('verilator', 2, check_uvm) || test_result
+        let test_result=TestEfm('verilator', 3, check_uvm) || test_result
         echo ''
 
         silent view test/errorformat.txt
@@ -103,7 +103,7 @@ function! RunTestEfm()
         echo ''
 
         silent view test/errorformat.txt
-        let test_result=TestEfm('ncverilog', 2, check_uvm) || test_result
+        let test_result=TestEfm('ncverilog', 3, check_uvm) || test_result
         echo ''
     endfor
 


### PR DESCRIPTION
Various improvements to `errorformat` configuration.
- Improve VCS `errorformat` entries.
- Allow using `:compiler` and `:compiler!` commands to select active `errorformat`.
- Add support for SpyGlass `errorformat`.
