### PR TITLE
Syntax/custom entries

### DIFF
--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -535,6 +535,9 @@ function verilog_systemverilog#CompleteCommand(lead, command, cursor)
           \ 'define',
           \ 'instance'
           \ ]
+    if (exists('g:verilog_syntax_custom'))
+      let valid_completions += keys(g:verilog_syntax_custom)
+    endif
     if (empty(filter(current_values, 'v:val =~ "^block"')))
       let valid_completions += [
             \ 'block',

--- a/doc/tags
+++ b/doc/tags
@@ -9,6 +9,7 @@
 b:verilog_disable_indent_lst	verilog_systemverilog.txt	/*b:verilog_disable_indent_lst*
 b:verilog_indent_assign_fix	verilog_systemverilog.txt	/*b:verilog_indent_assign_fix*
 b:verilog_indent_width	verilog_systemverilog.txt	/*b:verilog_indent_width*
+b:verilog_syntax_custom	verilog_systemverilog.txt	/*b:verilog_syntax_custom*
 b:verilog_syntax_fold_lst	verilog_systemverilog.txt	/*b:verilog_syntax_fold_lst*
 b:verilog_verbose	verilog_systemverilog.txt	/*b:verilog_verbose*
 g:verilog_disable_indent_lst	verilog_systemverilog.txt	/*g:verilog_disable_indent_lst*
@@ -19,6 +20,7 @@ g:verilog_efm_uvm_lst	verilog_systemverilog.txt	/*g:verilog_efm_uvm_lst*
 g:verilog_indent_assign_fix	verilog_systemverilog.txt	/*g:verilog_indent_assign_fix*
 g:verilog_indent_width	verilog_systemverilog.txt	/*g:verilog_indent_width*
 g:verilog_quick_syntax	verilog_systemverilog.txt	/*g:verilog_quick_syntax*
+g:verilog_syntax_custom	verilog_systemverilog.txt	/*g:verilog_syntax_custom*
 g:verilog_syntax_fold_lst	verilog_systemverilog.txt	/*g:verilog_syntax_fold_lst*
 g:verilog_verbose	verilog_systemverilog.txt	/*g:verilog_verbose*
 verilog-about	verilog_systemverilog.txt	/*verilog-about*

--- a/doc/verilog_systemverilog.txt
+++ b/doc/verilog_systemverilog.txt
@@ -456,6 +456,33 @@ Example:
     Note: The commands |:VerilogFoldingAdd| and |:VerilogFoldingRemove| are
     provided to allow an easier management of this variable.
 
+
+                             *b:verilog_syntax_custom* *g:verilog_syntax_custom*
+b:verilog_syntax_custom~
+g:verilog_syntax_custom~
+Default: undefined
+
+    Dictionary containing custom syntax declarations.
+    Each dictionary key is a list of syntax definitions that is a dictionary
+    with the following keys:
+        - `match`        - Match expression for a |:syn-match| entry.
+        - `match_start`  - Match start expression for a |:syn-region| entry.
+        - `match_end`    - Match end expression for a |:syn-region| entry.
+        - `highlight`    - Highlight to be used on as |:syn-matchgroup|.
+        - `syn_argument` - Other optional |:syn-arguments|.
+
+Example:
+
+>
+    let g:verilog_syntax_custom = {
+        \ 'spyglass' : [{
+            \ 'match_start' : '\/\/\s*spyglass\s\+disable_block\s\+\z(\(\w\|-\)\+\(\s\+\(\w\|-\)\+\)*\)',
+            \ 'match_end'   : '\/\/\s*spyglass\s\+enable_block\s\+\z1',
+            \ 'syn_argument': 'transparent keepend',
+            \ }],
+        \ }
+<
+
                                                       *g:verilog_quick_syntax*
 g:verilog_quick_syntax~
 Default: undefined

--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -256,7 +256,7 @@ function! s:GetContextIndent()
         return len(substitute(l:line, '?\s*\zs.*', '', ""))
       endif
       " Search for assignments (=, <=) that don't end in ";"
-      if l:line =~ s:vlog_assign . '[^;]*$'
+      if l:line =~ s:vlog_assign . '[^;]*$' && (!s:InsideAssign(l:lnum))
         if l:line !~ s:vlog_assign . '\s*$'
           " If there are values after the assignment, then use that column as
           " the indentation of the open statement.
@@ -393,6 +393,10 @@ endfunction
 
 function! s:IsComment(lnum)
   return synIDattr(synID(a:lnum, 1, 0), "name") == "verilogComment"
+endfunction
+
+function! s:InsideAssign(lnum)
+  return synIDattr(synID(a:lnum, 1, 0), "name") == "verilogAssign"
 endfunction
 
 " vi: sw=2 sts=2:

--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -64,4 +64,105 @@ let g:tagbar_type_verilog_systemverilog = {
     \ },
 \ }
 
+" Define regular expressions for Verilog/SystemVerilog statements
+let s:verilog_function_task_dequalifier =
+    \  '\('
+    \ .    '\('
+    \ .        'extern\s\+\(\(pure\s\+\)\?virtual\s\+\)\?'
+    \ .        '\|'
+    \ .        'pure\s\+virtual\s\+'
+    \ .    '\)'
+    \ .    '\(\(static\|protected\|local\)\s\+\)\?'
+    \ .'\)'
+
+let g:verilog_syntax = {
+      \ 'block'       : [{
+                        \ 'match_start' : '\<begin\>',
+                        \ 'match_end'   : '\<end\>',
+                        \ 'syn_argument': 'transparent',
+                        \ }],
+      \ 'block_named' : [{
+                        \ 'match_start' : '\<begin\>\s*:\s*\w\+',
+                        \ 'match_end'   : '\<end\>',
+                        \ 'syn_argument': 'transparent',
+                        \ }],
+      \ 'class'       : [{
+                        \ 'match_start' : '\<\(typedef\s\+\)\@<!\(interface\s\+\)\?class\>',
+                        \ 'match_end'   : '\<endclass\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent',
+                        \ }],
+      \ 'clocking'    : [{
+                        \ 'match_start' : '\<clocking\>',
+                        \ 'match_end'   : '\<endclocking\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'comment'     : [{
+                        \ 'match'       : '//.*',
+                        \ 'syn_argument': 'contains=verilogTodo,verilogDirective,@Spell'
+                        \ },
+                        \ {
+                        \ 'match_start' : '/\*',
+                        \ 'match_end'   : '\*/',
+                        \ 'syn_argument': 'contains=verilogTodo,verilogDirective,@Spell keepend'
+                        \ }],
+      \ 'covergroup'  : [{
+                        \ 'match_start' : '\<covergroup\>',
+                        \ 'match_end'   : '\<endgroup\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'define'      : [{
+                        \ 'match_start' : '`ifn\?def\>',
+                        \ 'match_mid'   : '`els\(e\|if\)\>',
+                        \ 'match_end'   : '`endif\>',
+                        \ }],
+      \ 'function'    : [{
+                        \ 'match_start' : s:verilog_function_task_dequalifier.'\@<!\<function\>',
+                        \ 'match_end'   : '\<endfunction\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'instance'    : [{
+                        \ 'match_start' : '^\s*\w\+\(\s*#\s*(\(.*)\s*\w\+\s*;\)\@!\|\s\+\(\<if\>\)\@!\w\+\s*(\)',
+                        \ 'match_end'   : ')\s*;',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'interface'   : [{
+                        \ 'match_start' : '\<interface\>\(\s\+class\)\@!',
+                        \ 'match_end'   : '\<endinterface\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'property'    : [{
+                        \ 'match_start' : '\<property\>',
+                        \ 'match_end'   : '\<endproperty\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'prototype'   : [{
+                        \ 'match'       : s:verilog_function_task_dequalifier.'\@<=\<\(task\|function\)\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ }],
+      \ 'sequence'    : [{
+                        \ 'match_start' : '\<sequence\>',
+                        \ 'match_end'   : '\<endsequence\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'specify'     : [{
+                        \ 'match_start' : '\<specify\>',
+                        \ 'match_end'   : '\<endspecify\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ 'task'        : [{
+                        \ 'match_start' : s:verilog_function_task_dequalifier.'\@<!\<task\>',
+                        \ 'match_end'   : '\<endtask\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
+      \ }
+
 " vi: set expandtab softtabstop=4 shiftwidth=4:

--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -76,6 +76,11 @@ let s:verilog_function_task_dequalifier =
     \ .'\)'
 
 let g:verilog_syntax = {
+      \ 'assign'      : [{
+                        \ 'match_start' : '[^=!]<\?=\(=\)\@!',
+                        \ 'match_end'   : '\ze\(;\|\*)\)',
+                        \ 'syn_argument': 'transparent',
+                        \ }],
       \ 'block'       : [{
                         \ 'match_start' : '\<begin\>',
                         \ 'match_end'   : '\<end\>',

--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -125,7 +125,7 @@ let g:verilog_syntax = {
                         \ 'syn_argument': 'transparent keepend',
                         \ }],
       \ 'instance'    : [{
-                        \ 'match_start' : '^\s*\w\+\(\s*#\s*(\(.*)\s*\w\+\s*;\)\@!\|\s\+\(\<if\>\)\@!\w\+\s*(\)',
+                        \ 'match_start' : '^\s*\zs\w\+\(\s*#\s*(\(.*)\s*\w\+\s*;\)\@!\|\s\+\(\<if\>\)\@!\w\+\s*(\)',
                         \ 'match_end'   : ')\s*;',
                         \ 'syn_argument': 'transparent keepend',
                         \ }],

--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -135,8 +135,14 @@ let g:verilog_syntax = {
                         \ 'highlight'   : 'verilogStatement',
                         \ 'syn_argument': 'transparent keepend',
                         \ }],
+      \ 'module'      : [{
+                        \ 'match_start' : '\<\(extern\s\+\)\@<!\<module\>',
+                        \ 'match_end'   : '\<endmodule\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend contains=ALLBUT,verilogInterface',
+                        \ }],
       \ 'property'    : [{
-                        \ 'match_start' : '\<property\>',
+                        \ 'match_start' : '\<\(\(assert\|cover\)\s\+\)\@<!\<property\>',
                         \ 'match_end'   : '\<endproperty\>',
                         \ 'highlight'   : 'verilogStatement',
                         \ 'syn_argument': 'transparent keepend',

--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -105,7 +105,7 @@ let g:verilog_syntax = {
                         \ {
                         \ 'match_start' : '/\*',
                         \ 'match_end'   : '\*/',
-                        \ 'syn_argument': 'contains=verilogTodo,verilogDirective,@Spell keepend'
+                        \ 'syn_argument': 'contains=verilogTodo,verilogDirective,@Spell keepend extend'
                         \ }],
       \ 'covergroup'  : [{
                         \ 'match_start' : '\<covergroup\>',

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -33,7 +33,7 @@ syn keyword verilogStatement   always and assign automatic buf
 syn keyword verilogStatement   bufif0 bufif1 cell cmos
 syn keyword verilogStatement   config deassign defparam design
 syn keyword verilogStatement   disable edge endconfig
-syn keyword verilogStatement   endgenerate endmodule
+syn keyword verilogStatement   endgenerate
 syn keyword verilogStatement   endprimitive endtable
 syn keyword verilogStatement   event force fork join
 syn keyword verilogStatement   join_any join_none forkjoin
@@ -41,7 +41,7 @@ syn keyword verilogStatement   generate genvar highz0 highz1 ifnone
 syn keyword verilogStatement   incdir include initial inout input
 syn keyword verilogStatement   instance integer large liblist
 syn keyword verilogStatement   library localparam macromodule medium
-syn keyword verilogStatement   module nand negedge nmos nor
+syn keyword verilogStatement   nand negedge nmos nor
 syn keyword verilogStatement   noshowcancelled not notif0 notif1 or
 syn keyword verilogStatement   output parameter pmos posedge primitive
 syn keyword verilogStatement   pull0 pull1 pulldown pullup
@@ -205,6 +205,7 @@ let s:verilog_syntax_order = [
             \ 'covergroup',
             \ 'function',
             \ 'interface',
+            \ 'module',
             \ 'property',
             \ 'sequence',
             \ 'specify',
@@ -217,14 +218,6 @@ for name in s:verilog_syntax_order
 endfor
 
 if index(s:verilog_syntax_fold, "block_nested") >= 0 || index(s:verilog_syntax_fold, "block_named") >= 0
-    syn region verilogBlockContainer
-        \ start="\<begin\>"
-        \ end="\<end\>"
-        \ skip="/[*/].*"
-        \ transparent
-        \ keepend extend
-        \ containedin=ALLBUT,verilogComment
-        \ contains=verilogBlock,verilogBlockNamed,verilogBlockEnd
     if index(s:verilog_syntax_fold, "block_nested") >= 0
         syn region verilogBlock
             \ matchgroup=verilogStatement
@@ -262,6 +255,13 @@ if index(s:verilog_syntax_fold, "block_nested") >= 0 || index(s:verilog_syntax_f
             \ contains=TOP
         "TODO break up if...else statements
     endif
+    syn region verilogBlockContainer
+        \ start="\<begin\>"
+        \ end="\<end\>"
+        \ skip="/[*/].*"
+        \ transparent
+        \ keepend extend
+        \ contains=verilogBlock,verilogBlockNamed,verilogBlockEnd
 elseif index(s:verilog_syntax_fold, "block") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
     syn region  verilogFold
         \ matchgroup=verilogStatement
@@ -274,14 +274,6 @@ else
 endif
 
 if index(s:verilog_syntax_fold, "define") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region verilogIfdefContainer
-        \ start="`ifn\?def\>"
-        \ end="`endif\>"
-        \ skip="/[*/].*"
-        \ transparent
-        \ keepend extend
-        \ containedin=ALLBUT,verilogComment
-        \ contains=verilogIfdef,verilogIfdefElse,verilogIfdefEndif
     syn region verilogIfdef
         \ start="`ifn\?def\>"
         \ end="^\s*`els\(e\|if\)\>"ms=s-1,me=s-1
@@ -305,6 +297,13 @@ if index(s:verilog_syntax_fold, "define") >= 0 || index(s:verilog_syntax_fold, "
         \ keepend
         \ contained
         \ contains=TOP
+    syn region verilogIfdefContainer
+        \ start="`ifn\?def\>"
+        \ end="`endif\>"
+        \ skip="/[*/].*"
+        \ transparent
+        \ keepend extend
+        \ contains=verilogIfdef,verilogIfdefElse,verilogIfdefEndif
 endif
 
 " Generate syntax definitions for comments after other standard syntax

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -138,71 +138,82 @@ endif
 syn keyword verilogObject      super
 syn match   verilogObject      "\<\w\+\ze\(::\|\.\)" contains=verilogNumber
 
-let s:verilog_function_task_dequalifier =
-    \  '\('
-    \ .    '\('
-    \ .        'extern\s\+\(\(pure\s\+\)\?virtual\s\+\)\?'
-    \ .        '\|'
-    \ .        'pure\s\+virtual\s\+'
-    \ .    '\)'
-    \ .    '\(\(static\|protected\|local\)\s\+\)\?'
-    \ .'\)'
-
-execute 'syn match verilogStatement "'.s:verilog_function_task_dequalifier.'\@<=\<\(task\|function\)\>"'
 
 syn match verilogStatement '\(typedef\s\+\)\@<=\<class\>'
+syn match verilogStatement 'interface\ze\s\+class\>'
+
+" Create syntax definition from g:verilog_syntax dictionary
+function! s:SyntaxCreate(name, verilog_syntax)
+    if exists('a:verilog_syntax[a:name]')
+        let verilog_syn_region_name = 'verilog'.substitute(a:name, '.*', '\u&', '')
+        for entry in a:verilog_syntax[a:name]
+            if exists('entry["match"]')
+                " syn-match definitions
+                let match = entry["match"]
+                let verilog_syn_match_cmd = 'syn match '.verilog_syn_region_name.' "'.match.'"'
+
+                if exists('entry["syn_argument"]')
+                    let verilog_syn_match_cmd .= ' '.entry["syn_argument"]
+                endif
+
+                execute verilog_syn_match_cmd
+            elseif exists('entry["match_start"]') && exists('entry["match_end"]')
+                " syn-region definitions
+
+                let region_start = entry["match_start"]
+                let region_end = entry["match_end"]
+
+                if verilog_systemverilog#VariableExists('verilog_quick_syntax')
+                    execute 'syn keyword verilogStatement '.region_start.' '.region_end
+                else
+                    let verilog_syn_region_cmd = 'syn region '.verilog_syn_region_name
+
+                    if exists('entry["highlight"]')
+                        let verilog_syn_region_cmd .= ' matchgroup='.entry["highlight"]
+                    endif
+
+                    let verilog_syn_region_cmd .=
+                        \  ' start="'.region_start.'"'
+                        \ .' end="'.region_end.'"'
+
+                    if exists('entry["syn_argument"]')
+                        let verilog_syn_region_cmd .= ' '.entry["syn_argument"]
+                    endif
+
+                    if (index(s:verilog_syntax_fold, a:name) >= 0 || index(s:verilog_syntax_fold, "all") >= 0)
+                        let verilog_syn_region_cmd .= ' fold'
+                    endif
+
+                    execute verilog_syn_region_cmd
+                endif
+            else
+                echoerr 'Incorrect syntax defintion for '.a:name
+            endif
+        endfor
+    end
+endfunction
 
 " Only enable folding if verilog_syntax_fold_lst is defined
 let s:verilog_syntax_fold=verilog_systemverilog#VariableGetValue("verilog_syntax_fold_lst")
 
-if index(s:verilog_syntax_fold, "instance") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region verilogFold
-        \ start="^\s*\w\+\(\s*#\s*(\|\s\+\(\<if\>\)\@!\w\+\s*(\)\(.*)\s*\w\+\s*;\)\@!"
-        \ end=")\s*;"
-        \ transparent
-        \ keepend
-        \ fold
-endif
+" Syntax priority list
+let s:verilog_syntax_order = [
+            \ 'instance',
+            \ 'prototype',
+            \ 'class',
+            \ 'clocking',
+            \ 'covergroup',
+            \ 'function',
+            \ 'interface',
+            \ 'property',
+            \ 'sequence',
+            \ 'specify',
+            \ 'task',
+            \ ]
 
-for name in ['class', 'clocking', 'covergroup', 'function', 'interface',
-    \ 'property', 'sequence', 'specify', 'task', ]
-
-    if name == 'task' || name == 'function'
-        let s:region_start = s:verilog_function_task_dequalifier.'\@<!\<'.name.'\>'
-    elseif name == 'class'
-        let s:region_start = '\(typedef\s\+\)\@<!\<\(interface\s\+\)\?class\>'
-    elseif name == 'interface'
-        let s:region_start = '\<interface\>\(\s\+class\)\@!'
-    else
-        let s:region_start = '\<'.name.'\>'
-    endif
-
-    if name == 'covergroup'
-        let s:region_end = '\<endgroup\>'
-    else
-        let s:region_end = '\<end'.name.'\>'
-    endif
-
-    if verilog_systemverilog#VariableExists('verilog_quick_syntax')
-        execute 'syn keyword verilogStatement '.s:region_start.' '.s:region_end
-    else
-        let s:verilog_syn_region_cmd =
-            \  'syn region verilog'.substitute(name, '.*', '\u&', '')
-            \ .' matchgroup=verilogStatement'
-            \ .' start="'.s:region_start.'"'
-            \ .' end="'.s:region_end.'"'
-            \ .' transparent'
-
-        if name != 'class'
-            let s:verilog_syn_region_cmd .= ' keepend'
-        endif
-
-        if index(s:verilog_syntax_fold, name) >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-            let s:verilog_syn_region_cmd .= ' fold'
-        endif
-
-        execute s:verilog_syn_region_cmd
-    endif
+" Generate syntax definitions for supported types
+for name in s:verilog_syntax_order
+    call s:SyntaxCreate(name, g:verilog_syntax)
 endfor
 
 if index(s:verilog_syntax_fold, "block_nested") >= 0 || index(s:verilog_syntax_fold, "block_named") >= 0
@@ -296,13 +307,11 @@ if index(s:verilog_syntax_fold, "define") >= 0 || index(s:verilog_syntax_fold, "
         \ contains=TOP
 endif
 
-" Expand verilogComment
-syn match verilogComment "//.*" contains=verilogTodo,verilogDirective,@Spell
-if index(s:verilog_syntax_fold, "comment") >= 0 || index(s:verilog_syntax_fold, "all") >= 0
-    syn region verilogComment start="/\*" end="\*/" contains=verilogTodo,verilogDirective,@Spell keepend fold
-else
-    syn region verilogComment start="/\*" end="\*/" contains=verilogTodo,verilogDirective,@Spell keepend
-endif
+" Generate syntax definitions for comments after other standard syntax
+" definitions to guarantee highest priority
+for name in ['comment']
+    call s:SyntaxCreate(name, g:verilog_syntax)
+endfor
 
 " Special comments: Synopsys directives
 syn match   verilogDirective   "//\s*synopsys\>.*$"
@@ -339,6 +348,7 @@ if version >= 508 || !exists("did_verilog_syn_inits")
    HiLink verilogLabel           Tag
    HiLink verilogNumber          Number
    HiLink verilogOperator        Special
+   HiLink verilogPrototype       Statement
    HiLink verilogStatement       Statement
    HiLink verilogGlobal          Define
    HiLink verilogDirective       SpecialComment

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -198,6 +198,7 @@ let s:verilog_syntax_fold=verilog_systemverilog#VariableGetValue("verilog_syntax
 
 " Syntax priority list
 let s:verilog_syntax_order = [
+            \ 'assign',
             \ 'instance',
             \ 'prototype',
             \ 'class',

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -313,6 +313,14 @@ for name in ['comment']
     call s:SyntaxCreate(name, g:verilog_syntax)
 endfor
 
+" Generate syntax definitions for custom types last to allow overriding
+" standard syntax
+if exists('g:verilog_syntax_custom')
+    for name in keys(g:verilog_syntax_custom)
+        call s:SyntaxCreate(name, g:verilog_syntax_custom)
+    endfor
+endif
+
 " Special comments: Synopsys directives
 syn match   verilogDirective   "//\s*synopsys\>.*$"
 syn region  verilogDirective   start="/\*\s*synopsys\>" end="\*/"

--- a/test/folding.v
+++ b/test/folding.v
@@ -265,6 +265,19 @@ end else begin:b3                                             //<1><1><1>
     do5();                                                    //<1><1><1>
 end                                                           //<1><1><1>
                                                               //<0><0><0>
+task something;                                               //<1><1><1>
+fork                                                          //<1><1><1>
+    begin                                                     //<2><2><1>
+        begin                                                 //<3><3><1>
+        end                                                   //<3><3><1>
+        /*                                                    //<3><3><2>
+        begin                                                 //<3><3><2>
+        end                                                   //<3><3><2>
+        */                                                    //<3><3><2>
+    end                                                       //<2><2><1>
+join                                                          //<1><1><1>
+endtask                                                       //<1><1><1>
+                                                              //<0><0><0>
 // spyglass disable_block SOMETHING                           //<1><1><1>
 assign a = b & c;                                             //<1><1><1>
 // spyglass enable_block SOMETHING                            //<1><1><1>

--- a/test/folding.v
+++ b/test/folding.v
@@ -13,7 +13,7 @@ begin                                                         //<2><2><1>
     state = something();                                      //<2><2><1>
     begin : block1                                            //<3><3><2>
         state = 2'b00;                                        //<3><3><2>
-        begin                                                 //<4><4><2>
+        if (a == b) begin                                     //<4><4><2>
             begin : block2                                    //<5><5><3>
             end // block2                                     //<5><5><3>
             state = 2'b11;                                    //<4><4><2>

--- a/test/folding.v
+++ b/test/folding.v
@@ -264,4 +264,9 @@ end else begin                                                //<1><1><1>
 end else begin:b3                                             //<1><1><1>
     do5();                                                    //<1><1><1>
 end                                                           //<1><1><1>
+                                                              //<0><0><0>
+// spyglass disable_block SOMETHING                           //<1><1><1>
+assign a = b & c;                                             //<1><1><1>
+// spyglass enable_block SOMETHING                            //<1><1><1>
+                                                              //<0><0><0>
 // vi: set number norelativenumber expandtab softtabstop=4 shiftwidth=4:

--- a/test/folding.v
+++ b/test/folding.v
@@ -217,6 +217,12 @@ task t_multi_line(                                            //<1><1><1>
                                                               //<1><1><1>
 endtask : t_multi_line                                        //<1><1><1>
                                                               //<0><0><0>
+  task t_multi_line_indented(                                 //<1><1><1>
+    input an_input                                            //<1><1><1>
+  );                                                          //<1><1><1>
+                                                              //<1><1><1>
+  endtask : t_multi_line                                      //<1><1><1>
+                                                              //<0><0><0>
 if (cond1) begin                                              //<1><1><0>
     do1();                                                    //<1><1><0>
 end else if (cond2) begin                                     //<1><1><0>

--- a/test/folding.v.html
+++ b/test/folding.v.html
@@ -219,6 +219,12 @@ uvm_blocking_put_port <span class="Special">#(</span>trans<span class="Special">
                                                               <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
 <span class="Statement">endtask</span> <span class="Special">:</span> t_multi_line                                        <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
                                                               <span class="Comment">//&lt;0&gt;&lt;0&gt;&lt;0&gt;</span>
+  <span class="Statement">task</span> <span class="Identifier">t_multi_line_indented</span><span class="Special">(</span>                                 <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+    <span class="Statement">input</span> an_input                                            <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+  <span class="Special">);</span>                                                          <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+                                                              <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+  <span class="Statement">endtask</span> <span class="Special">:</span> t_multi_line                                      <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+                                                              <span class="Comment">//&lt;0&gt;&lt;0&gt;&lt;0&gt;</span>
 <span class="Statement">if</span> <span class="Special">(</span>cond1<span class="Special">)</span> <span class="Statement">begin</span>                                              <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;0&gt;</span>
     <span class="Identifier">do1</span><span class="Special">();</span>                                                    <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;0&gt;</span>
 <span class="Statement">end</span> <span class="Statement">else</span> <span class="Statement">if</span> <span class="Special">(</span>cond2<span class="Special">)</span> <span class="Statement">begin</span>                                     <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;0&gt;</span>

--- a/test/folding.v.html
+++ b/test/folding.v.html
@@ -266,6 +266,11 @@ uvm_blocking_put_port <span class="Special">#(</span>trans<span class="Special">
 <span class="Statement">end</span> <span class="Statement">else</span> <span class="Statement">begin</span><span class="Special">:</span><span class="Special">b3</span>                                             <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
     <span class="Identifier">do5</span><span class="Special">();</span>                                                    <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
 <span class="Statement">end</span>                                                           <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+                                                              <span class="Comment">//&lt;0&gt;&lt;0&gt;&lt;0&gt;</span>
+<span class="Comment">// spyglass disable_block SOMETHING                           //&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+<span class="Statement">assign</span> a <span class="Special">=</span> b <span class="Special">&amp;</span> c<span class="Special">;</span>                                             <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+<span class="Comment">// spyglass enable_block SOMETHING</span>                            <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+                                                              <span class="Comment">//&lt;0&gt;&lt;0&gt;&lt;0&gt;</span>
 <span class="Comment">// vi&#0058; set number norelativenumber expandtab softtabstop=4 shiftwidth=4:</span>
 </pre>
 </body>

--- a/test/folding.v.html
+++ b/test/folding.v.html
@@ -267,6 +267,19 @@ uvm_blocking_put_port <span class="Special">#(</span>trans<span class="Special">
     <span class="Identifier">do5</span><span class="Special">();</span>                                                    <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
 <span class="Statement">end</span>                                                           <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
                                                               <span class="Comment">//&lt;0&gt;&lt;0&gt;&lt;0&gt;</span>
+<span class="Statement">task</span> something<span class="Special">;</span>                                               <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+<span class="Statement">fork</span>                                                          <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+    <span class="Statement">begin</span>                                                     <span class="Comment">//&lt;2&gt;&lt;2&gt;&lt;1&gt;</span>
+        <span class="Statement">begin</span>                                                 <span class="Comment">//&lt;3&gt;&lt;3&gt;&lt;1&gt;</span>
+        <span class="Statement">end</span>                                                   <span class="Comment">//&lt;3&gt;&lt;3&gt;&lt;1&gt;</span>
+        <span class="Comment">/*                                                    //&lt;3&gt;&lt;3&gt;&lt;2&gt;</span>
+<span class="Comment">        begin                                                 //&lt;3&gt;&lt;3&gt;&lt;2&gt;</span>
+<span class="Comment">        end                                                   //&lt;3&gt;&lt;3&gt;&lt;2&gt;</span>
+<span class="Comment">        */</span>                                                    <span class="Comment">//&lt;3&gt;&lt;3&gt;&lt;2&gt;</span>
+    <span class="Statement">end</span>                                                       <span class="Comment">//&lt;2&gt;&lt;2&gt;&lt;1&gt;</span>
+<span class="Statement">join</span>                                                          <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+<span class="Statement">endtask</span>                                                       <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
+                                                              <span class="Comment">//&lt;0&gt;&lt;0&gt;&lt;0&gt;</span>
 <span class="Comment">// spyglass disable_block SOMETHING                           //&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
 <span class="Statement">assign</span> a <span class="Special">=</span> b <span class="Special">&amp;</span> c<span class="Special">;</span>                                             <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>
 <span class="Comment">// spyglass enable_block SOMETHING</span>                            <span class="Comment">//&lt;1&gt;&lt;1&gt;&lt;1&gt;</span>

--- a/test/folding.v.html
+++ b/test/folding.v.html
@@ -15,7 +15,7 @@
     state <span class="Special">=</span> <span class="Identifier">something</span><span class="Special">();</span>                                      <span class="Comment">//&lt;2&gt;&lt;2&gt;&lt;1&gt;</span>
     <span class="Statement">begin</span> <span class="Special">:</span> <span class="Special">block1</span>                                            <span class="Comment">//&lt;3&gt;&lt;3&gt;&lt;2&gt;</span>
         state <span class="Special">=</span> <span class="Constant">2'b00</span><span class="Special">;</span>                                        <span class="Comment">//&lt;3&gt;&lt;3&gt;&lt;2&gt;</span>
-        <span class="Statement">begin</span>                                                 <span class="Comment">//&lt;4&gt;&lt;4&gt;&lt;2&gt;</span>
+        <span class="Statement">if</span> <span class="Special">(</span>a <span class="Special">==</span> b<span class="Special">)</span> <span class="Statement">begin</span>                                     <span class="Comment">//&lt;4&gt;&lt;4&gt;&lt;2&gt;</span>
             <span class="Statement">begin</span> <span class="Special">:</span> <span class="Special">block2</span>                                    <span class="Comment">//&lt;5&gt;&lt;5&gt;&lt;3&gt;</span>
             <span class="Statement">end</span> <span class="Comment">// block2                                     //&lt;5&gt;&lt;5&gt;&lt;3&gt;</span>
             state <span class="Special">=</span> <span class="Constant">2'b11</span><span class="Special">;</span>                                    <span class="Comment">//&lt;4&gt;&lt;4&gt;&lt;2&gt;</span>

--- a/test/indent.sv
+++ b/test/indent.sv
@@ -1018,4 +1018,11 @@ assert_label: assert property (
 );
 // End of copied code
 
+// Code from: // https://github.com/vhda/verilog_systemverilog.vim/issues/113
+assign a = b <= c &&
+           d <= e &&
+           f <= g &&
+           h <= i;
+// End of copied code
+
 // vim: set expandtab softtabstop=4 shiftwidth=4 nofoldenable:

--- a/test/run_test.vim
+++ b/test/run_test.vim
@@ -1,4 +1,16 @@
 "-----------------------------------------------------------------------
+" Global configurations
+"-----------------------------------------------------------------------
+" Configure custom syntax
+let g:verilog_syntax_custom = {
+    \ 'spyglass' : [{
+        \ 'match_start' : '\/\/\s*spyglass\s\+disable_block\s\+\z(\(\w\|-\)\+\(\s\+\(\w\|-\)\+\)*\)',
+        \ 'match_end'   : '\/\/\s*spyglass\s\+enable_block\s\+\z1',
+        \ 'syn_argument': 'transparent keepend',
+        \ }],
+    \ }
+
+"-----------------------------------------------------------------------
 " Syntax folding test
 "-----------------------------------------------------------------------
 function! RunTestFold()

--- a/test/run_test.vim
+++ b/test/run_test.vim
@@ -113,6 +113,7 @@ function! RunTestSyntax()
     set foldmethod=syntax
     set foldlevel=99
 
+    " Run syntax test for various folding configurations
     let g:verilog_syntax_fold_lst=''
     let test_result = TestSyntax('syntax.sv', g:verilog_syntax_fold_lst) || test_result
 

--- a/test/syntax.sv
+++ b/test/syntax.sv
@@ -1,3 +1,14 @@
+module mymodule(
+  input  wire a,
+  input  wire b,
+  `ifdef MACRO
+  input  wire c,
+  `endif
+  output wire y
+);
+
+endmodule
+
 `ifdef SYSTEM_VERILOG_KEYWORDS
 accept_on
 alias
@@ -50,7 +61,6 @@ endcase
 endchecker
 endconfig
 endgenerate
-endmodule
 endpackage
 endprimitive
 endprogram
@@ -109,7 +119,6 @@ macromodule
 matches
 medium
 modport
-module
 nand
 negedge
 nettype
@@ -240,6 +249,8 @@ function
 endfunction
 interface
 endinterface
+module
+endmodule
 property
 endproperty
 sequence

--- a/test/syntax.sv
+++ b/test/syntax.sv
@@ -249,6 +249,9 @@ endspecify
 task
 endtask
 `endif
+`ifdef COMPLEX_STATEMENTS
+typedef class c;
+`endif
 `ifdef TIME
 10ns
 100ns
@@ -324,6 +327,8 @@ endtask
 /*
 * TODO todo check
 */
+
+// Comment with DEFINE-ML
 
 always@(posedge clk or posedge rst)
 begin

--- a/test/syntax.sv.html
+++ b/test/syntax.sv.html
@@ -251,6 +251,9 @@
 <span class="Statement">task</span>
 <span class="Statement">endtask</span>
 <span class="PreProc">`endif</span>
+<span class="PreProc">`ifdef</span> <span class="Constant">COMPLEX_STATEMENTS</span>
+<span class="Type">typedef</span> <span class="Statement">class</span> c<span class="Special">;</span>
+<span class="PreProc">`endif</span>
 <span class="PreProc">`ifdef</span> <span class="Constant">TIME</span>
 <span class="Constant">10ns</span>
 <span class="Constant">100ns</span>
@@ -326,6 +329,8 @@
 <span class="Comment">/*</span>
 <span class="Comment">* </span><span class="Todo">TODO</span><span class="Comment"> todo check</span>
 <span class="Comment">*/</span>
+
+<span class="Comment">// Comment with DEFINE-ML</span>
 
 <span class="Statement">always</span><span class="Special">@(</span><span class="Statement">posedge</span> clk <span class="Statement">or</span> <span class="Statement">posedge</span> rst<span class="Special">)</span>
 <span class="Statement">begin</span>

--- a/test/syntax.sv.html
+++ b/test/syntax.sv.html
@@ -1,5 +1,16 @@
 <body>
 <pre>
+<span class="Statement">module</span> <span class="Identifier">mymodule</span><span class="Special">(</span>
+  <span class="Statement">input</span>  <span class="Statement">wire</span> a<span class="Special">,</span>
+  <span class="Statement">input</span>  <span class="Statement">wire</span> b<span class="Special">,</span>
+  <span class="PreProc">`ifdef</span> <span class="Constant">MACRO</span>
+  <span class="Statement">input</span>  <span class="Statement">wire</span> c<span class="Special">,</span>
+  <span class="PreProc">`endif</span>
+  <span class="Statement">output</span> <span class="Statement">wire</span> y
+<span class="Special">);</span>
+
+<span class="Statement">endmodule</span>
+
 <span class="PreProc">`ifdef</span> <span class="Constant">SYSTEM_VERILOG_KEYWORDS</span>
 <span class="Statement">accept_on</span>
 <span class="Statement">alias</span>
@@ -52,7 +63,6 @@
 <span class="Statement">endchecker</span>
 <span class="Statement">endconfig</span>
 <span class="Statement">endgenerate</span>
-<span class="Statement">endmodule</span>
 <span class="Statement">endpackage</span>
 <span class="Statement">endprimitive</span>
 <span class="Statement">endprogram</span>
@@ -111,7 +121,6 @@
 <span class="Statement">matches</span>
 <span class="Statement">medium</span>
 <span class="Statement">modport</span>
-<span class="Statement">module</span>
 <span class="Statement">nand</span>
 <span class="Statement">negedge</span>
 <span class="Statement">nettype</span>
@@ -242,6 +251,8 @@
 <span class="Statement">endfunction</span>
 <span class="Statement">interface</span>
 <span class="Statement">endinterface</span>
+<span class="Statement">module</span>
+<span class="Statement">endmodule</span>
 <span class="Statement">property</span>
 <span class="Statement">endproperty</span>
 <span class="Statement">sequence</span>


### PR DESCRIPTION
This PR introduces a big change to how syntax entries are defined: everything is declared in a global Dictionary that is initialized in the plugin file. While I initially considered using a script local (to the syntax file) variable, I want to provide the possibility of using the same Dictionary to obtain any Verilog/SystemVerilog related regular expressions on any file. The use of this global variable also allows everyone to modify it to experiment local changes before submitting a PR.

Building on top of this platform, I also introduce the support for custom syntax entries. I personally use this to add folding to SpyGlass disable blocks, which I have used as a documentation example and also for testing purposes. Such syntax definitions could easily be done in my .vimrc, but by using this plugin's structure I can also use the `VerilogFoldingAdd`/`VerilogFoldingRemove` commands to temporarily disable this custom folding when it is hindering my code analysis, for some reason. And if someone doesn't want it, then the feature is simply not used.

@lewis, hopefully this structure will help you on your updates to the indentation script. Please feel free to suggest or implement any other Dictionary key that you may need.