### PR TITLE
Add reference to verilog-instance plugin in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ $ git clone https://github.com/vhda/verilog_systemverilog.vim
 
 ## Other Vim addons helpful for Verilog/SystemVerilog
 
+### Verilog Instance
+[verilog-instance.vim][verilog-instance] creates SystemVerilog port instantiation from port declaration.
+Works on modules, tasks, functions and all other similar structures.
+
 ### Matchit
 
 This addon allows using <kbd>%</kbd> to jump between matching keywords as Vim already
@@ -244,15 +248,16 @@ page.
 [P]: https://github.com/junegunn/vim-plug
 [e]: https://ctags.io
 [t]: http://majutsushi.github.io/tagbar/
-[hl_matchit]:   https://github.com/vimtaku/hl_matchit.vim
-[supertab]:     https://github.com/ervandew/supertab
-[vim-omni]:     http://vimdoc.sourceforge.net/htmldoc/insert.html#i_CTRL-X_CTRL-O
-[vim-omnifunc]: http://vimdoc.sourceforge.net/htmldoc/options.html#'omnifunc'
-[vim-echom]:    http://vimdoc.sourceforge.net/htmldoc/eval.html#:echom
-[vim-errorformat]: http://vimdoc.sourceforge.net/htmldoc/options.html#'errorformat'
-[vim-makeprg]:  http://vimdoc.sourceforge.net/htmldoc/options.html#'makeprg'
-[vim-quickfix]: http://vimdoc.sourceforge.net/htmldoc/quickfix.html
-[vim-synfold]:  http://vimdoc.sourceforge.net/htmldoc/syntax.html#syntax
+[verilog-instance]: https://github.com/antoinemadec/vim-verilog-instance
+[hl_matchit]:       https://github.com/vimtaku/hl_matchit.vim
+[supertab]:         https://github.com/ervandew/supertab
+[vim-omni]:         http://vimdoc.sourceforge.net/htmldoc/insert.html#i_CTRL-X_CTRL-O
+[vim-omnifunc]:     http://vimdoc.sourceforge.net/htmldoc/options.html#'omnifunc'
+[vim-echom]:        http://vimdoc.sourceforge.net/htmldoc/eval.html#:echom
+[vim-errorformat]:  http://vimdoc.sourceforge.net/htmldoc/options.html#'errorformat'
+[vim-makeprg]:      http://vimdoc.sourceforge.net/htmldoc/options.html#'makeprg'
+[vim-quickfix]:     http://vimdoc.sourceforge.net/htmldoc/quickfix.html
+[vim-synfold]:      http://vimdoc.sourceforge.net/htmldoc/syntax.html#syntax
 
 
 <!-- Other links:


### PR DESCRIPTION
Hi Vitor,

I just added this vim plugin:
  https://github.com/antoinemadec/vim-verilog-instance

This creates SystemVerilog port instantiation from port declaration.
It is saving me a lot of time when I code in Verilog.
I have been using it for years now and I just found the courage to add features, re write it and release it to the world.

I was wondering if you could add it to the "Other vim plugins for Verilog/SystemVerilog" section of verilog_systemverilog's README ?
Also, feel free to report bugs or give me advice to make the plug-in clearer and cleaner.

Thanks in advance,
Antoine