### PR TITLE
Change function FollowInstanceSearchWord

### DIFF
--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -635,7 +635,7 @@ endfunction
 function verilog_systemverilog#FollowInstanceSearchWord(line, column)
   let @/='\<'.expand("<cword>").'\>'
   call verilog_systemverilog#FollowInstanceTag(a:line, a:column)
-  exec "normal /" . @/
+  exec ":/" . @/
   normal n
 endfunction
 " }}}


### PR DESCRIPTION
Using 'normal /' will conflict with the plugin 'haya14busa/incsearch.vim'.
When users map their search key '/' to incsearch, VerilogFollowPort will
stuck at 'normal /'. Using ':/' can easily avoid this problem.