### PR TITLE
Add curly-brace code folding

### DIFF
--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -128,6 +128,13 @@ let g:verilog_syntax = {
                         \ 'highlight'   : 'verilogStatement',
                         \ 'syn_argument': 'transparent keepend',
                         \ }],
+      \ 'curly'       : [{
+                        \ 'match_start' : '{',
+                        \ 'match_skip'  : '/[*/].*',
+                        \ 'match_end'   : '}',
+                        \ 'highlight'   : 'verilogOperator',
+                        \ 'syn_argument': 'transparent',
+                        \ }],
       \ 'define'      : [{
                         \ 'match_start' : '`ifn\?def\>',
                         \ 'match_mid'   : '`els\(e\|if\)\>',

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -173,9 +173,13 @@ function! s:SyntaxCreate(name, verilog_syntax)
                         let verilog_syn_region_cmd .= ' matchgroup='.entry["highlight"]
                     endif
 
-                    let verilog_syn_region_cmd .=
-                        \  ' start="'.region_start.'"'
-                        \ .' end="'.region_end.'"'
+                    let verilog_syn_region_cmd .= ' start="'.region_start.'"'
+
+                    if exists('entry["match_skip"]')
+                        let verilog_syn_region_cmd .= ' skip="'.entry["match_skip"].'"'
+                    endif
+
+                    let verilog_syn_region_cmd .= ' end="'.region_end.'"'
 
                     if exists('entry["syn_argument"]')
                         let verilog_syn_region_cmd .= ' '.entry["syn_argument"]
@@ -223,6 +227,7 @@ let s:verilog_syntax_order = [
             \ 'sequence',
             \ 'specify',
             \ 'task',
+            \ 'curly',
             \ ]
 
 " Generate syntax definitions for supported types


### PR DESCRIPTION
This implements a new `curly` option for verilog_syntax_fold_lst to allow code-folding of all the curly brace constructs in SV (enum, constraint, coverpoint, dist, inside) but also for large multi-line concatenations.

I did briefly start to separate this out into `curly` and `curly_nested` but discovered that I couldn't see a behavior difference between `block` and `block_nested` anymore (vim 8.1).  I'm seeing multiple levels of begin/end nesting when using `block`.  I personally always use nesting, so I haven't pursued `curly_nested` further until I understand the expected behavior.

My code base is holding up well with this, but it needs testing under varied coding styles.