### PR TITLE
Fix fork/join match_words to handle 'wait fork;'

### DIFF
--- a/ftplugin/verilog_systemverilog.vim
+++ b/ftplugin/verilog_systemverilog.vim
@@ -45,7 +45,7 @@ if exists("loaded_matchit")
     \ '`if\(n\)\?def\>:`elsif\>:`else\>:`endif\>,' .
     \ '\<module\>:\<endmodule\>,' .
     \ '\<if\>:\<else\>,' .
-    \ '\<fork\>:\<join\(_any\|_none\)\?\>,' .
+    \ '\<fork\>\s*;\@!$:\<join\(_any\|_none\)\?\>,' .
     \ '\<function\>:\<endfunction\>,' .
     \ '\<task\>:\<endtask\>,' .
     \ '\<specify\>:\<endspecify\>,' .


### PR DESCRIPTION
This commit resolves an issue that can be seen in [test/indent.sv:869-886](https://github.com/vhda/verilog_systemverilog.vim/blob/master/test/indent.sv#L869-L886) when using % to jump between the fork/join pairs with matchit.  The fork in 'wait fork' was beginning a new fork/join match pair, causing the initial fork in this block of code to be orphaned.