### PR TITLE
Add support for folding of OVM/UVM macros

### DIFF
--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -169,6 +169,12 @@ let g:verilog_syntax = {
                         \ 'highlight'   : 'verilogStatement',
                         \ 'syn_argument': 'transparent keepend contains=ALLBUT,verilogInterface',
                         \ }],
+      \ 'ovm'         : [{
+                        \ 'match_start' : '`\<\(ovm\|uvm\)_\a\+_utils_begin\>',
+                        \ 'match_end'   : '`\<\(ovm\|uvm\)_\a\+_utils_end\>',
+                        \ 'highlight'   : 'verilogStatement',
+                        \ 'syn_argument': 'transparent keepend',
+                        \ }],
       \ 'property'    : [{
                         \ 'match_start' : '\<\(\(assert\|cover\)\s\+\)\@<!\<property\>',
                         \ 'match_end'   : '\<endproperty\>',

--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -219,6 +219,7 @@ let s:verilog_syntax_order = [
             \ 'function',
             \ 'interface',
             \ 'module',
+            \ 'ovm',
             \ 'property',
             \ 'sequence',
             \ 'specify',


### PR DESCRIPTION
This commit adds a new folding option 'ovm' which will fold ovm/uvm macro constructs that have a begin/end

I originally wanted to name the new dictionary entry 'verif' since it encompasses both OVM and UVM, but for some reason the dictionary entry would not work when I named it either 'verif' or 'uvm'.  But naming it 'ovm' does work.  I can't explain that.   'ovm' isn't a terrible name but it's a deprecated library, so it's not ideal.

Let me know if you would like additions to the test cases to cover this change.