### PR TITLE
Fix project's language classification on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Hide fixtures in diffs and language stats on GitHub
+test/*.html linguist-vendored
+
+# Fix misclassification of Verilog files
+test/*.v linguist-language=SystemVerilog


### PR DESCRIPTION
GitHub is currently classifying this repository as an HTML project because of the combined weight of the [`test/*.html` files](https://github.com/vhda/verilog_systemverilog.vim/search?l=html) (accounting for 54.5% of the codebase's source code).

The library used by GitHub for performing language analysis has a [mechanism](https://github.com/github/linguist#overrides) to exclude files from language breakdown graphs; merging this PR will cause the repo to appear as a Vim Script project.
