### PR TITLE
Generic: Add global variable to disable support for Tagbar

### DIFF
--- a/plugin/verilog_systemverilog.vim
+++ b/plugin/verilog_systemverilog.vim
@@ -27,43 +27,45 @@ command! -nargs=+ -complete=customlist,verilog_systemverilog#CompleteCommand
             \ call verilog_systemverilog#PopFromVariable('verilog_efm_uvm_lst', '<args>')
 
 " Configure tagbar
-" This requires a recent version of universal-ctags
-let g:tagbar_type_verilog_systemverilog = {
-    \ 'ctagstype'   : 'SystemVerilog',
-    \ 'kinds'       : [
-        \ 'b:blocks:1:1',
-        \ 'c:constants:1:0',
-        \ 'e:events:1:0',
-        \ 'f:functions:1:1',
-        \ 'm:modules:0:1',
-        \ 'n:nets:1:0',
-        \ 'p:ports:1:0',
-        \ 'r:registers:1:0',
-        \ 't:tasks:1:1',
-        \ 'A:assertions:1:1',
-        \ 'C:classes:0:1',
-        \ 'V:covergroups:0:1',
-        \ 'I:interfaces:0:1',
-        \ 'M:modport:0:1',
-        \ 'K:packages:0:1',
-        \ 'P:programs:0:1',
-        \ 'R:properties:0:1',
-        \ 'T:typedefs:0:1'
-    \ ],
-    \ 'sro'         : '.',
-    \ 'kind2scope'  : {
-        \ 'm' : 'module',
-        \ 'b' : 'block',
-        \ 't' : 'task',
-        \ 'f' : 'function',
-        \ 'C' : 'class',
-        \ 'V' : 'covergroup',
-        \ 'I' : 'interface',
-        \ 'K' : 'package',
-        \ 'P' : 'program',
-        \ 'R' : 'property'
-    \ },
-\ }
+if !exists("g:tagbar_type_verilog_systemverilog")
+    " This requires a recent version of universal-ctags
+    let g:tagbar_type_verilog_systemverilog = {
+        \ 'ctagstype'   : 'SystemVerilog',
+        \ 'kinds'       : [
+            \ 'b:blocks:1:1',
+            \ 'c:constants:1:0',
+            \ 'e:events:1:0',
+            \ 'f:functions:1:1',
+            \ 'm:modules:0:1',
+            \ 'n:nets:1:0',
+            \ 'p:ports:1:0',
+            \ 'r:registers:1:0',
+            \ 't:tasks:1:1',
+            \ 'A:assertions:1:1',
+            \ 'C:classes:0:1',
+            \ 'V:covergroups:0:1',
+            \ 'I:interfaces:0:1',
+            \ 'M:modport:0:1',
+            \ 'K:packages:0:1',
+            \ 'P:programs:0:1',
+            \ 'R:properties:0:1',
+            \ 'T:typedefs:0:1'
+        \ ],
+        \ 'sro'         : '.',
+        \ 'kind2scope'  : {
+            \ 'm' : 'module',
+            \ 'b' : 'block',
+            \ 't' : 'task',
+            \ 'f' : 'function',
+            \ 'C' : 'class',
+            \ 'V' : 'covergroup',
+            \ 'I' : 'interface',
+            \ 'K' : 'package',
+            \ 'P' : 'program',
+            \ 'R' : 'property'
+        \ },
+    \ }
+endif
 
 " Define regular expressions for Verilog/SystemVerilog statements
 let s:verilog_function_task_dequalifier =


### PR DESCRIPTION
Current implementation only supports Universal Ctags, so this variable
allows disabling this configuration when the user does not have access
to this version of Ctags.