### PR TITLE
Add option to disable constant highlight

### DIFF
--- a/syntax/verilog_systemverilog.vim
+++ b/syntax/verilog_systemverilog.vim
@@ -104,7 +104,9 @@ syn keyword verilogRepeat      do while foreach
 syn match   verilogGlobal      "`[a-zA-Z_][a-zA-Z0-9_$]\+"
 syn match   verilogGlobal      "$[a-zA-Z0-9_$]\+"
 
-syn match   verilogConstant    "\<[A-Z][A-Z0-9_$]*\>"
+if !exists('g:verilog_disable_constant_highlight')
+    syn match   verilogConstant    "\<[A-Z][A-Z0-9_$]*\>"
+endif
 
 syn match   verilogNumber      "\(\d\+\)\?'[sS]\?[bB]\s*[0-1_xXzZ?]\+"
 syn match   verilogNumber      "\(\d\+\)\?'[sS]\?[oO]\s*[0-7_xXzZ?]\+"


### PR DESCRIPTION
Because the word which starts with uppercase letter is regarded as constant, signal name with the same rule is also highlighted. This is not applied with the name which starts with lowercase letter. Due to it, signal name is sometimes highlighted but sometimes not. I added an option to avoid this phenomenon which just disable constant highlight.

![image](https://user-images.githubusercontent.com/845232/82467029-1ef48980-9afc-11ea-8f3f-5ea2d30d7808.png)
