### PR TITLE
Indent: Add option to align assignments with symbol

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -9,6 +9,7 @@
 :VerilogReturnInstance	verilog_systemverilog.txt	/*:VerilogReturnInstance*
 b:verilog_disable_indent_lst	verilog_systemverilog.txt	/*b:verilog_disable_indent_lst*
 b:verilog_indent_assign_fix	verilog_systemverilog.txt	/*b:verilog_indent_assign_fix*
+b:verilog_indent_assign_on_symbol	verilog_systemverilog.txt	/*b:verilog_indent_assign_on_symbol*
 b:verilog_indent_block_on_keyword	verilog_systemverilog.txt	/*b:verilog_indent_block_on_keyword*
 b:verilog_indent_width	verilog_systemverilog.txt	/*b:verilog_indent_width*
 b:verilog_syntax_custom	verilog_systemverilog.txt	/*b:verilog_syntax_custom*
@@ -21,6 +22,7 @@ g:verilog_efm_level	verilog_systemverilog.txt	/*g:verilog_efm_level*
 g:verilog_efm_quickfix_clean	verilog_systemverilog.txt	/*g:verilog_efm_quickfix_clean*
 g:verilog_efm_uvm_lst	verilog_systemverilog.txt	/*g:verilog_efm_uvm_lst*
 g:verilog_indent_assign_fix	verilog_systemverilog.txt	/*g:verilog_indent_assign_fix*
+g:verilog_indent_assign_on_symbol	verilog_systemverilog.txt	/*g:verilog_indent_assign_on_symbol*
 g:verilog_indent_block_on_keyword	verilog_systemverilog.txt	/*g:verilog_indent_block_on_keyword*
 g:verilog_indent_width	verilog_systemverilog.txt	/*g:verilog_indent_width*
 g:verilog_navigate_split	verilog_systemverilog.txt	/*g:verilog_navigate_split*

--- a/doc/verilog_systemverilog.txt
+++ b/doc/verilog_systemverilog.txt
@@ -384,6 +384,33 @@ Example:
     let b:verilog_indent_assign_fix = 1
 <
 
+         *b:verilog_indent_assign_on_symbol* *g:verilog_indent_assign_on_symbol*
+b:verilog_indent_assign_on_symbol~
+g:verilog_indent_assign_on_symbol~
+Default: undefined
+
+    Indent lines following an assignment on the assignment symbol (= or <=).
+>
+        assign y = a
+                 & b;
+        assign z =
+                 c && d;
+<
+    By default, the indentation script aligns to the first word after the
+    assignment symbol, if existing:
+>
+        assign y = a
+                   & b;
+        assign z =
+            c && d;
+<
+
+Example:
+
+>
+    let b:verilog_indent_assign_on_symbol = 1
+<
+
          *b:verilog_indent_block_on_keyword* *g:verilog_indent_block_on_keyword*
 b:verilog_indent_block_on_keyword~
 g:verilog_indent_block_on_keyword~

--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -278,8 +278,14 @@ function! s:GetContextIndent()
       if l:line =~ s:vlog_assign . '[^;]*$' && (!s:InsideAssign(l:lnum))
         if l:line !~ s:vlog_assign . '\s*$'
           " If there are values after the assignment, then use that column as
-          " the indentation of the open statement.
-          let l:assign = substitute(l:line, s:vlog_assign .'\s*\zs.*', '', "")
+          " the indentation of the open statement, or the column of the
+          " assign symbol itself if "verilog_indent_assign_on_symbol" is
+          " defined.
+          if (verilog_systemverilog#VariableExists("verilog_indent_assign_on_symbol"))
+            let l:assign = substitute(l:line, s:vlog_assign .'.*', '=', "")
+          else
+            let l:assign = substitute(l:line, s:vlog_assign .'\s*\zs.*', '', "")
+          endif
           let l:assign_offset = len(l:assign)
           call verilog_systemverilog#Verbose(
             "Increasing indent for an open assignment with values (by " . l:assign_offset .")."


### PR DESCRIPTION
By default the indentation script aligns with the first word after the
assignment symbol, but issue #209 requests that following lines show be
aligned with the assignment symbol itself.