### PR TITLE
Use shiftwidth function if available

### DIFF
--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -71,6 +71,8 @@ function! GetVerilogSystemVerilogIndent()
 
   if verilog_systemverilog#VariableExists('verilog_indent_width')
     let s:offset = verilog_systemverilog#VariableGetValue('verilog_indent_width')
+  elseif exists('?shiftwidth')
+    let s:offset = shiftwidth()
   else
     let s:offset = &sw
   endif


### PR DESCRIPTION
The shiftwidth() function, implemented in Vim 7.3.694, allows an effective 'shiftwidth' value to be determined based on 'tabstop' when the 'shiftwidth' setting is 0. When the 'shiftwidth' setting is nonzero, shiftwidth() returns the configured value as normal.
This PR uses the new function if it is available.