### PR TITLE
feat: VerilogFollow* support for multiple tag matches

### DIFF
--- a/autoload/verilog_systemverilog.vim
+++ b/autoload/verilog_systemverilog.vim
@@ -675,7 +675,7 @@ function verilog_systemverilog#FollowInstanceTag(line, column)
     exec "wincmd ".g:verilog_navigate_split
   endif
   if values[1] != ""
-    execute "tag " . values[1]
+    execute "tjump " . values[1]
   endif
 endfunction
 " }}}


### PR DESCRIPTION
Currently, VerilogFollow* jump in the first tag match.
This mean if you have 2 version of the same module, you have 50% chances of jumping in the wrong one.

This commit uses `tjump` instead of `tag`:
- if only 1 match, behave exactly like before
- if more than 1 match, prompt the user to know which module is the right one

Cheers :smiley: 