### PR TITLE
Indent: Improve support for randcase

### DIFF
--- a/ftplugin/verilog_systemverilog.vim
+++ b/ftplugin/verilog_systemverilog.vim
@@ -41,7 +41,7 @@ if exists("loaded_matchit")
   let b:match_ignorecase=0
   let b:match_words=
     \ '\<begin\>:\<end\>,' .
-    \ '\<case\>\|\<casex\>\|\<casez\>:\<endcase\>,' .
+    \ '\<case\>\|\<casex\>\|\<casez\>\|\<randcase\>:\<endcase\>,' .
     \ '`if\(n\)\?def\>:`elsif\>:`else\>:`endif\>,' .
     \ '\<module\>:\<endmodule\>,' .
     \ '\<if\>:\<else\>,' .

--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -32,9 +32,6 @@ let s:vlog_sens_list      = '\(@\s*(.*)\)'
 let s:vlog_always         = '\<always\(_ff\|_comb\|_latch\)\?\>\s*' . s:vlog_sens_list . '\?'
 let s:vlog_method         = '^\(\s*pure\s\+virtual\|\s*extern\)\@!.*\<\(function\|task\)\>\s\+\(\[.*\]\s*\)\?\w\+'
 
-let s:vlog_block_start    = '\<\(begin\|case\|^\s*fork\)\>\|{\|('
-let s:vlog_block_end      = '\<\(end\|endcase\|join\(_all\|_none\)\?\)\>\|}\|)'
-
 let s:vlog_module         = '\<\(extern\s\+\)\@<!module\>'
 let s:vlog_interface      = '\(virtual\s\+\)\@<!\<interface\>\s*\(\<class\>\)\@!\w\+.*[^,]$'
 let s:vlog_package        = '\<package\>'
@@ -48,7 +45,7 @@ let s:vlog_clocking       = g:verilog_syntax['clocking'][0]['match_start']
 let s:vlog_preproc        = '^\s*`ifn\?def\>'
 let s:vlog_define         = '^\s*`define\>'
 
-let s:vlog_case           = '\<case[zx]\?\>\s*('
+let s:vlog_case           = '\<case[zx]\?\>\s*(\|\<randcase\>'
 let s:vlog_join           = '\<join\(_any\|_none\)\?\>'
 
 let s:vlog_block_decl     = '\(\<\(while\|if\|foreach\|for\|repeat\)\>\s*(\)\|\<\(initial\|forever\|else\|do\)\>\|' . s:vlog_always

--- a/test/indent.sv
+++ b/test/indent.sv
@@ -526,6 +526,12 @@ case (Signal)
 endcase
 // End of copied code
 
+randcase
+    1: value <= 0;
+    2: value <= 1;
+    3: value <= 2;
+endcase
+
 interface class base;
 
     pure virtual function void a(input int unsigned N, ref t Data);

--- a/test/indent.sv.html
+++ b/test/indent.sv.html
@@ -528,6 +528,12 @@ MyModule <span class="Special">#(</span>
 <span class="Statement">endcase</span>
 <span class="Comment">// End of copied code</span>
 
+<span class="Statement">randcase</span>
+    <span class="Constant">1</span><span class="Special">:</span> value <span class="Special">&lt;=</span> <span class="Constant">0</span><span class="Special">;</span>
+    <span class="Constant">2</span><span class="Special">:</span> value <span class="Special">&lt;=</span> <span class="Constant">1</span><span class="Special">;</span>
+    <span class="Constant">3</span><span class="Special">:</span> value <span class="Special">&lt;=</span> <span class="Constant">2</span><span class="Special">;</span>
+<span class="Statement">endcase</span>
+
 <span class="Statement">interface</span> <span class="Statement">class</span> base<span class="Special">;</span>
 
     <span class="Statement">pure</span> <span class="Statement">virtual</span> <span class="Statement">function</span> <span class="Statement">void</span> <span class="Identifier">a</span><span class="Special">(</span><span class="Statement">input</span> <span class="Statement">int</span> <span class="Statement">unsigned</span> <span class="Constant">N</span><span class="Special">,</span> <span class="Statement">ref</span> t Data<span class="Special">);</span>

--- a/test/indent_standalone.sv
+++ b/test/indent_standalone.sv
@@ -526,6 +526,12 @@ case (Signal)
 endcase
 // End of copied code
 
+randcase
+    1: value <= 0;
+    2: value <= 1;
+    3: value <= 2;
+endcase
+
 interface class base;
 
     pure virtual function void a(input int unsigned N, ref t Data);


### PR DESCRIPTION
* Include 'randcase' keyword in b:match_words
* Drop s:vlog_block_start/end from indent/verilog_systemverilog.vim since they are no longer in use
* Add simple indent test for randcase

Fixes #245.